### PR TITLE
chore(*): bump version

### DIFF
--- a/packages/firebase_auth/firebase_auth_dart/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_auth_dart
 description: TODO
 homepage: https://firebase.flutter.dev
 repository: https://github.com/invertase/flutterfire_dart
-version: 0.1.1-dev.0
+version: 0.1.1-dev.1
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/firebase_core/firebase_core_dart/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core_dart
 description: Pure Dart implementation of FlutterFire core API.
 homepage: https://firebase.flutter.dev
 repository: https://github.com/invertase/flutterfire_dart
-version: 0.1.1-dev.0
+version: 0.1.1-dev.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/firebase_functions/firebase_functions_dart/pubspec.yaml
+++ b/packages/firebase_functions/firebase_functions_dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_functions_dart
 description: Pure Dart implementation of FlutterFire CloudFunctions API.
 homepage: https://firebase.flutter.dev
 repository: https://github.com/invertase/flutterfire_dart
-version: 0.1.0-dev.0
+version: 0.1.0-dev.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Bumping `firebase_functions_dart` package version from 0.1.0-dev.0 -> 0.1.0-dev.1
0.1.0-dev.1 was referenced in `firebase_functions_desktop`.

Edit:
Bumping `firebase_core_dart` package version from 0.1.1-dev.0 -> 0.1.1-dev.1