### PR TITLE
fix(firebase_auth): map exception code to match FlutterFire plugins

### DIFF
--- a/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
@@ -435,7 +435,8 @@ class FirebaseAuth {
       }
 
       final authException = FirebaseAuthException(code: errorCode);
-      log('$authException', name: 'firebase_auth_dart/${authException.code}');
+      log('${authException.message}',
+          name: 'firebase_auth_dart/${authException.code}');
 
       return authException;
     } else if (e is Exception) {

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth_exception.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth_exception.dart
@@ -46,7 +46,12 @@ class FirebaseAuthException extends FirebaseException implements Exception {
   FirebaseAuthException({String code = 'UKNOWN', String? message})
       : super(
           plugin: 'firebase_auth',
-          code: code,
+          code: _getCode(code),
           message: error[code] ?? message,
         );
+
+  /// Map to error code that matches the rest of FlutterFire plugins.
+  static String _getCode(String code) {
+    return code.toLowerCase().replaceAll('error_', '').replaceAll('_', '-');
+  }
 }

--- a/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.dart
+++ b/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.dart
@@ -63,9 +63,9 @@ Future<http.Response> _mockSuccessRequests(http.Request req) async {
 
 Future<http.Response> _mockFailedRequests(http.Request req) async {
   if (req.url.path.contains('verifyPassword')) {
-    return errorResponse('EMAIL_NOT_FOUND');
+    return errorResponse('email-not-found');
   } else if (req.url.path.contains('createAuthUri')) {
-    return errorResponse('INVALID_IDENTIFIER');
+    return errorResponse('invalid-identifier');
   } else {
     return http.Response('Error: Unknown endpoint', 404);
   }
@@ -151,7 +151,7 @@ void main() {
         expect(
           () => auth.signInWithEmailAndPassword(mockEmail, mockPassword),
           throwsA(isA<FirebaseAuthException>()
-              .having((e) => e.code, 'error code', 'EMAIL_NOT_FOUND')),
+              .having((e) => e.code, 'error code', 'email-not-found')),
         );
       });
       test('sign-out.', () async {
@@ -219,7 +219,7 @@ void main() {
           () => auth.fetchSignInMethodsForEmail(''),
           throwsA(
             isA<FirebaseAuthException>().having((p0) => p0.code,
-                'invalid identifier code', 'INVALID_IDENTIFIER'),
+                'invalid identifier code', 'invalid-identifier'),
           ),
         );
       });
@@ -321,7 +321,7 @@ void main() {
           ),
           throwsA(
             isA<FirebaseAuthException>()
-                .having((p0) => p0.code, 'error code', 'EMAIL_NOT_FOUND'),
+                .having((p0) => p0.code, 'error code', 'email-not-found'),
           ),
         );
       });
@@ -373,7 +373,7 @@ void main() {
           user?.delete(),
           throwsA(
             isA<FirebaseAuthException>()
-                .having((p0) => p0.code, 'error code', 'USER_NOT_FOUND'),
+                .having((p0) => p0.code, 'error code', 'user-not-found'),
           ),
         );
         expect(
@@ -383,7 +383,7 @@ void main() {
           ),
           throwsA(
             isA<FirebaseAuthException>()
-                .having((p0) => p0.code, 'error code', 'EMAIL_NOT_FOUND'),
+                .having((p0) => p0.code, 'error code', 'email-not-found'),
           ),
         );
       });


### PR DESCRIPTION
In `firebase_auth` for Flutter on other platforms, the error code is small case with `-` instead of `_`.
The response coming from IDP isn't matching, here adding a method to get the correct format.

e.g. `WEAK_PASSWORD` ⇒ `weak-password`