### PR TITLE
refactor(firebase_auth)!: change auth state streams to methods

### DIFF
--- a/packages/firebase_auth/firebase_auth_dart/README.md
+++ b/packages/firebase_auth/firebase_auth_dart/README.md
@@ -38,10 +38,10 @@ FirebaseAuth auth = FirebaseAuth.instanceFor(app: secondaryApp);
 
 You can listen to changes in authentication states through the following streams:
 
-1. `onAuthStateChanged()`: fires event upon changes in `User` state, on sign in and sign out.
+1. `authStateChanges()`: fires event upon changes in `User` state, on sign in and sign out.
    ```dart
    FirebaseAuth.instance
-  .onAuthStateChanged()
+  .authStateChanges()
   .listen((User? user) {
     if (user == null) {
       print('User is currently signed out!');
@@ -50,10 +50,10 @@ You can listen to changes in authentication states through the following streams
     }
   });
    ```
-2. `onIdTokenChanged()`: in addition to listening to the changes in `User` state, it also fires events when the current user's token changes.
+2. `idTokenChanges()`: in addition to listening to the changes in `User` state, it also fires events when the current user's token changes.
    ```dart
    FirebaseAuth.instance
-  .onIdTokenChanged()
+  .idTokenChanges()
   .listen((User? user) {
     if (user == null) {
       print('User is currently signed out!');
@@ -152,7 +152,7 @@ The User class is returned from any authentication state listeners, or as part o
 
     ```dart
     FirebaseAuth.instance
-      .onAuthStateChanged()
+      .authStateChanges()
       .listen((User? user) {
         if (user != null) {
           print(user.uid);

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
@@ -77,16 +77,18 @@ class FirebaseAuth {
   /// Sends events when the users sign-in state changes.
   ///
   /// If the value is `null`, there is no signed-in user.
-  Stream<User?> authStateChanges() {
-    return _changeController.stream;
+  Stream<User?> authStateChanges() async* {
+    yield currentUser;
+    yield* _changeController.stream;
   }
 
   /// Sends events for changes to the signed-in user's ID token,
   /// which includes sign-in, sign-out, and token refresh events.
   ///
   /// If the value is `null`, there is no signed-in user.
-  Stream<User?> idTokenChanges() {
-    return _idTokenChangedController.stream;
+  Stream<User?> idTokenChanges() async* {
+    yield currentUser;
+    yield* _idTokenChangedController.stream;
   }
 
   /// Helper method to update currentUser and events.

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
@@ -70,14 +70,14 @@ class FirebaseAuth {
   /// not.
   ///
   /// You should not use this getter to determine the users current state,
-  /// instead use [onAuthStateChanged], or [onIdTokenChanged] to
+  /// instead use [authStateChanges], or [idTokenChanges] to
   /// subscribe to updates.
   User? currentUser;
 
   /// Sends events when the users sign-in state changes.
   ///
   /// If the value is `null`, there is no signed-in user.
-  Stream<User?> get onAuthStateChanged {
+  Stream<User?> authStateChanges() {
     return _changeController.stream;
   }
 
@@ -85,7 +85,7 @@ class FirebaseAuth {
   /// which includes sign-in, sign-out, and token refresh events.
   ///
   /// If the value is `null`, there is no signed-in user.
-  Stream<User?> get onIdTokenChanged {
+  Stream<User?> idTokenChanges() {
     return _idTokenChangedController.stream;
   }
 
@@ -105,7 +105,7 @@ class FirebaseAuth {
   /// Attempts to sign in a user with the given email address and password.
   ///
   /// If successful, it also signs the user in into the app and updates
-  /// any [onAuthStateChanged], or [onIdTokenChanged] stream listeners.
+  /// any [authStateChanges], or [idTokenChanges] stream listeners.
   ///
   /// **Important**: You must enable Email & Password accounts in the Auth
   /// section of the Firebase console before being able to use them.
@@ -341,7 +341,7 @@ class FirebaseAuth {
   /// etc.) and returns additional identity provider data.
   ///
   /// If successful, it also signs the user in into the app and updates
-  /// any [onAuthStateChanged], or [onIdTokenChanged] stream listeners.
+  /// any [authStateChanges], or [idTokenChanges] stream listeners.
   ///
   /// If the user doesn't have an account already, one will be created
   /// automatically.
@@ -473,7 +473,7 @@ class FirebaseAuth {
   /// Signs out the current user.
   ///
   /// If successful, it also updates
-  /// any [onAuthStateChanged], or [onIdTokenChanged] stream listeners.
+  /// any [authStateChanges], or [idTokenChanges] stream listeners.
   Future<void> signOut() async {
     try {
       _updateCurrentUserAndEvents(null);

--- a/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.dart
+++ b/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.dart
@@ -107,8 +107,8 @@ void main() {
 
       await auth.useAuthEmulator();
 
-      onAuthStateChanged = StreamQueue(auth.onAuthStateChanged);
-      onIdTokenChanged = StreamQueue(auth.onIdTokenChanged);
+      onAuthStateChanged = StreamQueue(auth.authStateChanges());
+      onIdTokenChanged = StreamQueue(auth.idTokenChanges());
     });
 
     setUp(() async {
@@ -116,9 +116,9 @@ void main() {
 
       fakeAuth = MockFirebaseAuth();
 
-      when(fakeAuth.onAuthStateChanged)
+      when(fakeAuth.authStateChanges())
           .thenAnswer((_) => Stream.fromIterable([user]));
-      when(fakeAuth.onIdTokenChanged)
+      when(fakeAuth.idTokenChanges())
           .thenAnswer((_) => Stream.fromIterable([user]));
       when(fakeAuth.signInAnonymously())
           .thenAnswer((_) => Future<UserCredential>.value(userCred));
@@ -283,7 +283,7 @@ void main() {
         final oldToken = await userCred.user!.getIdToken();
 
         expect(
-          await (await fakeAuth.onIdTokenChanged.last)!.getIdToken(true),
+          await (await fakeAuth.idTokenChanges().last)!.getIdToken(true),
           isNot(equals(oldToken)),
         );
       });

--- a/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.dart
+++ b/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.dart
@@ -90,8 +90,8 @@ void main() {
     );
   }
 
-  late StreamQueue<User?> onAuthStateChanged;
-  late StreamQueue<User?> onIdTokenChanged;
+  late StreamQueue<User?> authStateChanges;
+  late StreamQueue<User?> idTokenChanges;
   group('$FirebaseAuth', () {
     setUpAll(() async {
       const options = FirebaseOptions(
@@ -107,8 +107,8 @@ void main() {
 
       await auth.useAuthEmulator();
 
-      onAuthStateChanged = StreamQueue(auth.authStateChanges());
-      onIdTokenChanged = StreamQueue(auth.idTokenChanges());
+      authStateChanges = StreamQueue(auth.authStateChanges());
+      idTokenChanges = StreamQueue(auth.idTokenChanges());
     });
 
     setUp(() async {
@@ -141,8 +141,8 @@ void main() {
 
         expect(credential, isA<UserCredential>());
         expect(credential.user!.email, equals(mockEmail));
-        expect(await onAuthStateChanged.next, isA<User>());
-        expect(await onIdTokenChanged.next, isA<User>());
+        expect(await authStateChanges.next, isA<User>());
+        expect(await idTokenChanges.next, isA<User>());
 
         await auth.signOut();
       });
@@ -160,8 +160,8 @@ void main() {
         await auth.signOut();
 
         expect(auth.currentUser, isNull);
-        expect(await onAuthStateChanged.next, isNull);
-        expect(await onIdTokenChanged.next, isNull);
+        expect(await authStateChanges.next, isNull);
+        expect(await idTokenChanges.next, isNull);
       });
     });
 
@@ -174,8 +174,8 @@ void main() {
         expect((await auth.currentUser!.getIdTokenResult()).signInProvider,
             'anonymous');
 
-        expect(await onAuthStateChanged.next, isA<User>());
-        expect(await onIdTokenChanged.next, isA<User>());
+        expect(await authStateChanges.next, isA<User>());
+        expect(await idTokenChanges.next, isA<User>());
       });
       test(
         'sign-up return current user if already sign-in anonymously.',
@@ -193,8 +193,8 @@ void main() {
         await auth.signOut();
 
         expect(auth.currentUser, isNull);
-        expect(await onAuthStateChanged.next, isNull);
-        expect(await onIdTokenChanged.next, isNull);
+        expect(await authStateChanges.next, isNull);
+        expect(await idTokenChanges.next, isNull);
       });
     });
 

--- a/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.mocks.dart
+++ b/packages/firebase_auth/firebase_auth_dart/test/firebase_auth_dart_test.mocks.dart
@@ -18,13 +18,13 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 
-class _FakeIdTokenResult_0 extends _i1.Fake implements _i2.IdTokenResult {}
+class _FakeUser_0 extends _i1.Fake implements _i2.User {}
 
-class _FakeUserCredential_1 extends _i1.Fake implements _i2.UserCredential {}
+class _FakeIdTokenResult_1 extends _i1.Fake implements _i2.IdTokenResult {}
 
-class _FakeFirebaseApp_2 extends _i1.Fake implements _i3.FirebaseApp {}
+class _FakeUserCredential_2 extends _i1.Fake implements _i2.UserCredential {}
 
-class _FakeException_3 extends _i1.Fake implements Exception {}
+class _FakeFirebaseApp_3 extends _i1.Fake implements _i3.FirebaseApp {}
 
 class _FakeFirebaseAuth_4 extends _i1.Fake implements _i2.FirebaseAuth {}
 
@@ -52,6 +52,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   String get uid =>
       (super.noSuchMethod(Invocation.getter(#uid), returnValue: '') as String);
   @override
+  _i4.Future<_i2.User> unlink(String? providerId) =>
+      (super.noSuchMethod(Invocation.method(#unlink, [providerId]),
+              returnValue: Future<_i2.User>.value(_FakeUser_0()))
+          as _i4.Future<_i2.User>);
+  @override
   _i4.Future<void> delete() =>
       (super.noSuchMethod(Invocation.method(#delete, []),
           returnValue: Future<void>.value(),
@@ -65,14 +70,14 @@ class MockUser extends _i1.Mock implements _i2.User {
           [bool? forceRefresh = false]) =>
       (super.noSuchMethod(Invocation.method(#getIdTokenResult, [forceRefresh]),
               returnValue:
-                  Future<_i2.IdTokenResult>.value(_FakeIdTokenResult_0()))
+                  Future<_i2.IdTokenResult>.value(_FakeIdTokenResult_1()))
           as _i4.Future<_i2.IdTokenResult>);
   @override
   _i4.Future<_i2.UserCredential> linkWithCredential(
           _i2.AuthCredential? credential) =>
       (super.noSuchMethod(Invocation.method(#linkWithCredential, [credential]),
               returnValue:
-                  Future<_i2.UserCredential>.value(_FakeUserCredential_1()))
+                  Future<_i2.UserCredential>.value(_FakeUserCredential_2()))
           as _i4.Future<_i2.UserCredential>);
   @override
   _i4.Future<_i2.UserCredential> reauthenticateWithCredential(
@@ -80,7 +85,7 @@ class MockUser extends _i1.Mock implements _i2.User {
       (super.noSuchMethod(
               Invocation.method(#reauthenticateWithCredential, [credential]),
               returnValue:
-                  Future<_i2.UserCredential>.value(_FakeUserCredential_1()))
+                  Future<_i2.UserCredential>.value(_FakeUserCredential_2()))
           as _i4.Future<_i2.UserCredential>);
   @override
   _i4.Future<void> reload() =>
@@ -135,7 +140,7 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
 
   @override
   _i3.FirebaseApp get app => (super.noSuchMethod(Invocation.getter(#app),
-      returnValue: _FakeFirebaseApp_2()) as _i3.FirebaseApp);
+      returnValue: _FakeFirebaseApp_3()) as _i3.FirebaseApp);
   @override
   set app(_i3.FirebaseApp? _app) =>
       super.noSuchMethod(Invocation.setter(#app, _app),
@@ -145,28 +150,24 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
       super.noSuchMethod(Invocation.setter(#currentUser, _currentUser),
           returnValueForMissingStub: null);
   @override
-  _i4.Stream<_i2.User?> get onAuthStateChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAuthStateChanged),
-          returnValue: Stream<_i2.User?>.empty()) as _i4.Stream<_i2.User?>);
-  @override
-  _i4.Stream<_i2.User?> get onIdTokenChanged =>
-      (super.noSuchMethod(Invocation.getter(#onIdTokenChanged),
-          returnValue: Stream<_i2.User?>.empty()) as _i4.Stream<_i2.User?>);
-  @override
   void setApiClient(_i5.Client? client) =>
       super.noSuchMethod(Invocation.method(#setApiClient, [client]),
           returnValueForMissingStub: null);
   @override
-  void updateCurrentUserAndEvents(_i2.User? user) =>
-      super.noSuchMethod(Invocation.method(#updateCurrentUserAndEvents, [user]),
-          returnValueForMissingStub: null);
+  _i4.Stream<_i2.User?> authStateChanges() =>
+      (super.noSuchMethod(Invocation.method(#authStateChanges, []),
+          returnValue: Stream<_i2.User?>.empty()) as _i4.Stream<_i2.User?>);
+  @override
+  _i4.Stream<_i2.User?> idTokenChanges() =>
+      (super.noSuchMethod(Invocation.method(#idTokenChanges, []),
+          returnValue: Stream<_i2.User?>.empty()) as _i4.Stream<_i2.User?>);
   @override
   _i4.Future<_i2.UserCredential> signInWithEmailAndPassword(
           String? email, String? password) =>
       (super.noSuchMethod(
               Invocation.method(#signInWithEmailAndPassword, [email, password]),
               returnValue:
-                  Future<_i2.UserCredential>.value(_FakeUserCredential_1()))
+                  Future<_i2.UserCredential>.value(_FakeUserCredential_2()))
           as _i4.Future<_i2.UserCredential>);
   @override
   _i4.Future<_i2.UserCredential> createUserWithEmailAndPassword(
@@ -174,7 +175,7 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
       (super.noSuchMethod(
           Invocation.method(#createUserWithEmailAndPassword, [email, password]),
           returnValue:
-              Future<_i2.UserCredential>.value(_FakeUserCredential_1())) as _i4
+              Future<_i2.UserCredential>.value(_FakeUserCredential_2())) as _i4
           .Future<_i2.UserCredential>);
   @override
   _i4.Future<List<String>> fetchSignInMethodsForEmail(String? email) => (super
@@ -202,13 +203,13 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
   _i4.Future<_i2.UserCredential> signInAnonymously() =>
       (super.noSuchMethod(Invocation.method(#signInAnonymously, []),
               returnValue:
-                  Future<_i2.UserCredential>.value(_FakeUserCredential_1()))
+                  Future<_i2.UserCredential>.value(_FakeUserCredential_2()))
           as _i4.Future<_i2.UserCredential>);
   @override
   _i4.Future<_i2.UserCredential> signInWithPopup() =>
       (super.noSuchMethod(Invocation.method(#signInWithPopup, []),
               returnValue:
-                  Future<_i2.UserCredential>.value(_FakeUserCredential_1()))
+                  Future<_i2.UserCredential>.value(_FakeUserCredential_2()))
           as _i4.Future<_i2.UserCredential>);
   @override
   _i4.Future<_i2.UserCredential> signInWithCredential(
@@ -216,7 +217,7 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
       (super.noSuchMethod(
               Invocation.method(#signInWithCredential, [credential]),
               returnValue:
-                  Future<_i2.UserCredential>.value(_FakeUserCredential_1()))
+                  Future<_i2.UserCredential>.value(_FakeUserCredential_2()))
           as _i4.Future<_i2.UserCredential>);
   @override
   _i4.Future<_i2.UserCredential> signInWithEmailLink(
@@ -224,7 +225,7 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
       (super.noSuchMethod(
               Invocation.method(#signInWithEmailLink, [email, emailLink]),
               returnValue:
-                  Future<_i2.UserCredential>.value(_FakeUserCredential_1()))
+                  Future<_i2.UserCredential>.value(_FakeUserCredential_2()))
           as _i4.Future<_i2.UserCredential>);
   @override
   _i4.Future<void> verifyPhoneNumber({String? phoneNumber}) =>
@@ -239,10 +240,6 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i4.Future<String?> refreshIdToken() =>
-      (super.noSuchMethod(Invocation.method(#refreshIdToken, []),
-          returnValue: Future<String?>.value()) as _i4.Future<String?>);
-  @override
   _i4.Future<Map<dynamic, dynamic>> useAuthEmulator(
           {String? host = r'localhost', int? port = 9099}) =>
       (super.noSuchMethod(
@@ -250,10 +247,6 @@ class MockFirebaseAuth extends _i1.Mock implements _i2.FirebaseAuth {
           returnValue:
               Future<Map<dynamic, dynamic>>.value(<dynamic, dynamic>{})) as _i4
           .Future<Map<dynamic, dynamic>>);
-  @override
-  Exception getException(Object? e) =>
-      (super.noSuchMethod(Invocation.method(#getException, [e]),
-          returnValue: _FakeException_3()) as Exception);
   @override
   String toString() => super.toString();
 }

--- a/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
+++ b/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
@@ -32,7 +32,7 @@ class FirebaseAuthDesktop extends FirebaseAuthPlatform {
     _idTokenChangesListeners[app.name] =
         StreamController<UserPlatform?>.broadcast();
 
-    _auth!.onAuthStateChanged.map((auth_dart.User? dartUser) {
+    _auth!.authStateChanges().map((auth_dart.User? dartUser) {
       if (dartUser == null) {
         return null;
       }
@@ -41,7 +41,7 @@ class FirebaseAuthDesktop extends FirebaseAuthPlatform {
       _authStateChangesListeners[app.name]!.add(user);
     });
 
-    _auth!.onIdTokenChanged.map((auth_dart.User? dartUser) {
+    _auth!.idTokenChanges().map((auth_dart.User? dartUser) {
       if (dartUser == null) {
         return null;
       }


### PR DESCRIPTION
Auth state streams in the Dart package are **inconsistent** with the FlutterFire interface, this PR rename them to match the interface.

Previously as getters: `onAuthStateChanged`, `onIdTokenChanged`
New as methods: `authStateChanges()`, `idTokenChanges()`