### PR TITLE
refactor: 🔨 identity toolkit api layer

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -181,7 +181,7 @@ linter:
     - use_if_null_to_convert_nulls_to_bools
     - use_is_even_rather_than_modulo
     - use_key_in_widget_constructors
-    - use_late_for_private_fields_and_variables
+    # - use_late_for_private_fields_and_variables
     - use_named_constants
     - use_raw_strings
     - use_rethrow_when_possible

--- a/packages/firebase_auth/firebase_auth_dart/lib/firebase_auth_dart.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/firebase_auth_dart.dart
@@ -16,8 +16,7 @@ import 'package:firebaseapis/identitytoolkit/v3.dart' as idp;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
-import 'src/api/api.dart' show API, APIConfig;
-import 'src/api/authentication/recaptcha/recaptcha_verifier.dart' as verifier;
+import 'src/api/api.dart';
 import 'src/firebase_auth_exception.dart';
 import 'src/providers/email_auth.dart';
 import 'src/providers/enums.dart';
@@ -27,8 +26,7 @@ import 'src/providers/phone_auth.dart';
 import 'src/providers/twitter_auth.dart';
 import 'src/utils/jwt.dart';
 
-export 'src/api/authentication/recaptcha/recaptcha_args.dart';
-export 'src/api/authentication/recaptcha/recaptcha_verifier.dart';
+export 'src/api/api.dart' show RecaptchaVerifier, RecaptchaArgs, API, APIConfig;
 export 'src/auth_provider.dart';
 export 'src/firebase_auth_exception.dart';
 export 'src/providers/email_auth.dart';

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/account.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/account.dart
@@ -9,8 +9,13 @@ class UserAccount extends APIDelegate {
   // ignore: public_member_api_docs
   const UserAccount(API api) : super(api);
 
-  /// TODO: write endpoint details
-  Future<DeleteAccountResponse> delete(String idToken, String uid) async {
+  /// Delete a current user account.
+  ///
+  /// Common error codes:
+  /// - `INVALID_ID_TOKEN`: The user's credential is no longer valid. The user must sign in again.
+  /// - `USER_NOT_FOUND`: There is no user record corresponding to this identifier.
+  /// The user may have been deleted.
+  Future<void> delete(String idToken, String uid) {
     return api.identityToolkit.deleteAccount(
       IdentitytoolkitRelyingpartyDeleteAccountRequest(
         idToken: idToken,
@@ -19,25 +24,37 @@ class UserAccount extends APIDelegate {
     );
   }
 
-  /// TODO: write endpoint details
-  Future<SetAccountInfoResponse> deleteLinkedAccount(
+  /// Unlink a provider from a current user.
+  ///
+  /// Common error codes:
+  /// `INVALID_ID_TOKEN`: The user's credential is no longer valid. The user must sign in again.
+  Future<Map<String, dynamic>> deleteLinkedAccount(
     String idToken,
     String providerId,
   ) async {
-    return api.identityToolkit.setAccountInfo(
+    final response = await api.identityToolkit.setAccountInfo(
       IdentitytoolkitRelyingpartySetAccountInfoRequest(
         idToken: idToken,
         deleteProvider: [providerId],
       ),
     );
+
+    return response.toJson();
   }
 
-  /// TODO: write endpoint details
-  Future<UserInfo> getAccountInfo(String? idToken) async {
-    final _response = await api.identityToolkit.getAccountInfo(
+  /// Get a user's data.
+  ///
+  /// Common error codes:
+  /// `INVALID_ID_TOKEN`: The user's credential is no longer valid. The user must sign in again.
+  /// `USER_NOT_FOUND`: There is no user record corresponding to this identifier.
+  /// The user may have been deleted.
+  Future<Map<String, dynamic>> getAccountInfo(String idToken) async {
+    final response = await api.identityToolkit.getAccountInfo(
       IdentitytoolkitRelyingpartyGetAccountInfoRequest(idToken: idToken),
     );
 
-    return _response.users![0];
+    final json = response.users![0].toJson();
+
+    return json;
   }
 }

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/account.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/account.dart
@@ -5,15 +5,13 @@ part of api;
 /// - `setAccountInfo`: delete a linked auth provider.
 /// - `getAccountInfo`: get a user's data.
 @internal
-class UserAccount {
+class UserAccount extends APIDelegate {
   // ignore: public_member_api_docs
-  const UserAccount(this._api);
-
-  final API _api;
+  const UserAccount(API api) : super(api);
 
   /// TODO: write endpoint details
   Future<DeleteAccountResponse> delete(String idToken, String uid) async {
-    return _api.identityToolkit.deleteAccount(
+    return api.identityToolkit.deleteAccount(
       IdentitytoolkitRelyingpartyDeleteAccountRequest(
         idToken: idToken,
         localId: uid,
@@ -26,7 +24,7 @@ class UserAccount {
     String idToken,
     String providerId,
   ) async {
-    return _api.identityToolkit.setAccountInfo(
+    return api.identityToolkit.setAccountInfo(
       IdentitytoolkitRelyingpartySetAccountInfoRequest(
         idToken: idToken,
         deleteProvider: [providerId],
@@ -36,7 +34,7 @@ class UserAccount {
 
   /// TODO: write endpoint details
   Future<UserInfo> getAccountInfo(String? idToken) async {
-    final _response = await _api.identityToolkit.getAccountInfo(
+    final _response = await api.identityToolkit.getAccountInfo(
       IdentitytoolkitRelyingpartyGetAccountInfoRequest(idToken: idToken),
     );
 

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/account.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/account.dart
@@ -1,0 +1,45 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `deleteAccount`: delete a current user.
+/// - `setAccountInfo`: delete a linked auth provider.
+/// - `getAccountInfo`: get a user's data.
+@internal
+class UserAccount {
+  // ignore: public_member_api_docs
+  const UserAccount(this._api);
+
+  final API _api;
+
+  /// TODO: write endpoint details
+  Future<DeleteAccountResponse> delete(String idToken, String uid) async {
+    return _api.identityToolkit.deleteAccount(
+      IdentitytoolkitRelyingpartyDeleteAccountRequest(
+        idToken: idToken,
+        localId: uid,
+      ),
+    );
+  }
+
+  /// TODO: write endpoint details
+  Future<SetAccountInfoResponse> deleteLinkedAccount(
+    String idToken,
+    String providerId,
+  ) async {
+    return _api.identityToolkit.setAccountInfo(
+      IdentitytoolkitRelyingpartySetAccountInfoRequest(
+        idToken: idToken,
+        deleteProvider: [providerId],
+      ),
+    );
+  }
+
+  /// TODO: write endpoint details
+  Future<UserInfo> getAccountInfo(String? idToken) async {
+    final _response = await _api.identityToolkit.getAccountInfo(
+      IdentitytoolkitRelyingpartyGetAccountInfoRequest(idToken: idToken),
+    );
+
+    return _response.users![0];
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/email_and_password.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/email_and_password.dart
@@ -1,0 +1,53 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `setAccountInfo`: change a user's email or password.
+/// - `resetPassword`: apply a password reset change.
+@internal
+class EmailAndPasswordAccount {
+  // ignore: public_member_api_docs
+  const EmailAndPasswordAccount(this._api);
+
+  final API _api;
+
+  /// TODO: write endpoint details
+  Future<SetAccountInfoResponse> updateEmail(
+    String newEmail,
+    String idToken,
+    String uid,
+  ) async {
+    final _response = await _api.identityToolkit.setAccountInfo(
+      IdentitytoolkitRelyingpartySetAccountInfoRequest(
+        email: newEmail,
+        idToken: idToken,
+        localId: uid,
+      ),
+    );
+    return _response;
+  }
+
+  /// TODO: write endpoint details
+  Future<SetAccountInfoResponse> updatePassword(
+    String idToken, {
+    String? newPassword,
+  }) async {
+    return _api.identityToolkit.setAccountInfo(
+      IdentitytoolkitRelyingpartySetAccountInfoRequest(
+        idToken: idToken,
+        password: newPassword,
+      ),
+    );
+  }
+
+  /// TODO: write endpoint details
+  Future<String> resetPassword(String? code, String? newPassword) async {
+    final _response = await _api.identityToolkit.resetPassword(
+      IdentitytoolkitRelyingpartyResetPasswordRequest(
+        newPassword: newPassword,
+        oobCode: code,
+      ),
+    );
+
+    return _response.email!;
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/email_and_password.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/email_and_password.dart
@@ -4,11 +4,9 @@ part of api;
 /// - `setAccountInfo`: change a user's email or password.
 /// - `resetPassword`: apply a password reset change.
 @internal
-class EmailAndPasswordAccount {
+class EmailAndPasswordAccount extends APIDelegate {
   // ignore: public_member_api_docs
-  const EmailAndPasswordAccount(this._api);
-
-  final API _api;
+  const EmailAndPasswordAccount(API api) : super(api);
 
   /// TODO: write endpoint details
   Future<SetAccountInfoResponse> updateEmail(
@@ -16,7 +14,7 @@ class EmailAndPasswordAccount {
     String idToken,
     String uid,
   ) async {
-    final _response = await _api.identityToolkit.setAccountInfo(
+    final _response = await api.identityToolkit.setAccountInfo(
       IdentitytoolkitRelyingpartySetAccountInfoRequest(
         email: newEmail,
         idToken: idToken,
@@ -31,7 +29,7 @@ class EmailAndPasswordAccount {
     String idToken, {
     String? newPassword,
   }) async {
-    return _api.identityToolkit.setAccountInfo(
+    return api.identityToolkit.setAccountInfo(
       IdentitytoolkitRelyingpartySetAccountInfoRequest(
         idToken: idToken,
         password: newPassword,
@@ -41,7 +39,7 @@ class EmailAndPasswordAccount {
 
   /// TODO: write endpoint details
   Future<String> resetPassword(String? code, String? newPassword) async {
-    final _response = await _api.identityToolkit.resetPassword(
+    final _response = await api.identityToolkit.resetPassword(
       IdentitytoolkitRelyingpartyResetPasswordRequest(
         newPassword: newPassword,
         oobCode: code,

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/email_and_password.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/email_and_password.dart
@@ -8,7 +8,11 @@ class EmailAndPasswordAccount extends APIDelegate {
   // ignore: public_member_api_docs
   const EmailAndPasswordAccount(API api) : super(api);
 
-  /// TODO: write endpoint details
+  /// Change a user's email.
+  ///
+  /// Common error codes:
+  /// - `EMAIL_EXISTS`: The email address is already in use by another account.
+  /// - `INVALID_ID_TOKEN`:The user's credential is no longer valid. The user must sign in again.
   Future<SetAccountInfoResponse> updateEmail(
     String newEmail,
     String idToken,
@@ -24,7 +28,11 @@ class EmailAndPasswordAccount extends APIDelegate {
     return _response;
   }
 
-  /// TODO: write endpoint details
+  /// Change a user's password.
+  ///
+  /// Common error codes:
+  /// - `INVALID_ID_TOKEN`:The user's credential is no longer valid. The user must sign in again.
+  /// - `WEAK_PASSWORD`: The password must be 6 characters long or more.
   Future<SetAccountInfoResponse> updatePassword(
     String idToken, {
     String? newPassword,
@@ -37,7 +45,14 @@ class EmailAndPasswordAccount extends APIDelegate {
     );
   }
 
-  /// TODO: write endpoint details
+  /// Apply a password reset change.
+  ///
+  /// Common error codes:
+  /// - `OPERATION_NOT_ALLOWED`: Password sign-in is disabled for this project.
+  /// - `EXPIRED_OOB_CODE`: The action code has expired.
+  /// - `INVALID_OOB_CODE`: The action code is invalid. This can happen if the
+  /// code is malformed, expired, or has already been used.
+  /// - `USER_DISABLED`: The user account has been disabled by an administrator.
   Future<String> resetPassword(String? code, String? newPassword) async {
     final _response = await api.identityToolkit.resetPassword(
       IdentitytoolkitRelyingpartyResetPasswordRequest(

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/profile.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/profile.dart
@@ -1,0 +1,34 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `setAccountInfo`: change a user's displayName or photoUrl.
+@protected
+class UserProfile {
+  // ignore: public_member_api_docs
+  UserProfile(this._api);
+
+  final API _api;
+
+  /// TODO: write endpoint details
+  Future<SetAccountInfoResponse> updateProfile(
+    String idToken,
+    String uid, {
+    String? photoUrl = '',
+    String? displayName = '',
+  }) async {
+    final _response = await _api.identityToolkit.setAccountInfo(
+      IdentitytoolkitRelyingpartySetAccountInfoRequest(
+        displayName: displayName == '' ? null : displayName,
+        photoUrl: photoUrl == '' ? null : photoUrl,
+        idToken: idToken,
+        localId: uid,
+        returnSecureToken: true,
+        deleteAttribute: [
+          if (photoUrl == null) 'PHOTO_URL',
+          if (displayName == null) 'DISPLAY_NAME'
+        ],
+      ),
+    );
+    return _response;
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/profile.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/profile.dart
@@ -7,7 +7,10 @@ class UserProfile extends APIDelegate {
   // ignore: public_member_api_docs
   const UserProfile(API api) : super(api);
 
-  /// TODO: write endpoint details
+  /// Update a user's profile (display name / photo URL).
+  ///
+  /// Common error codes:
+  /// - `INVALID_ID_TOKEN`: The user's credential is no longer valid. The user must sign in again.
   Future<SetAccountInfoResponse> updateProfile(
     String idToken,
     String uid, {

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/profile.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/account_managament/profile.dart
@@ -3,11 +3,9 @@ part of api;
 /// Class wrapping methods that calls to the following endpoints:
 /// - `setAccountInfo`: change a user's displayName or photoUrl.
 @protected
-class UserProfile {
+class UserProfile extends APIDelegate {
   // ignore: public_member_api_docs
-  UserProfile(this._api);
-
-  final API _api;
+  const UserProfile(API api) : super(api);
 
   /// TODO: write endpoint details
   Future<SetAccountInfoResponse> updateProfile(
@@ -16,7 +14,7 @@ class UserProfile {
     String? photoUrl = '',
     String? displayName = '',
   }) async {
-    final _response = await _api.identityToolkit.setAccountInfo(
+    final _response = await api.identityToolkit.setAccountInfo(
       IdentitytoolkitRelyingpartySetAccountInfoRequest(
         displayName: displayName == '' ? null : displayName,
         photoUrl: photoUrl == '' ? null : photoUrl,

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
@@ -59,6 +59,15 @@ abstract class SignInResponse {
   Map<String, dynamic> toJson();
 }
 
+/// All API classes calling to IDP API must extend this template.
+abstract class APIDelegate {
+  /// Construct a new [APIDelegate].
+  const APIDelegate(this.api);
+
+  /// The [API] instance containing required configurations to make the requests.
+  final API api;
+}
+
 /// Configurations necessary for making all idp requests.
 @protected
 class APIConfig {
@@ -152,7 +161,7 @@ class API {
   SignUp get signUp => SignUp(this);
 
   /// A delegate getter used to perform all requests
-  /// for custon token related operations.
+  /// for custom token related operations.
   CustomTokenAuth get customTokenAuth => CustomTokenAuth(this);
 
   /// A delegate getter used to perform all requests

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.
 
-// ignore_for_file: require_trailing_commas, avoid_dynamic_calls, use_setters_to_change_properties, implementation_imports
+// ignore_for_file: implementation_imports
 
 library api;
 
@@ -36,6 +36,28 @@ part 'authentication/sign_up.dart';
 part 'authentication/sms.dart';
 part 'authentication/token.dart';
 part 'emulator.dart';
+
+/// Response template to be returned from all sign in methods.
+abstract class SignInResponse {
+  /// Construct a new [SignInResponse].
+  SignInResponse(
+    this.idToken,
+    this.refreshToken, [
+    this.isNewUser = false,
+  ]);
+
+  /// User's Firebase Id Token.
+  final String idToken;
+
+  /// User's refresh token.
+  final String refreshToken;
+
+  /// Whether this user is new or not.
+  final bool isNewUser;
+
+  /// Map representation of this object.
+  Map<String, dynamic> toJson();
+}
 
 /// Configurations necessary for making all idp requests.
 @protected
@@ -83,7 +105,7 @@ class API {
   /// The API configurations of this instance.
   final APIConfig apiConfig;
 
-  late http.Client _client;
+  http.Client? _client;
 
   String? _languageCode;
 
@@ -92,7 +114,9 @@ class API {
   String? get languageCode => _languageCode;
 
   /// Change the HTTP client for the purpose of testing.
-  void setApiClient(http.Client client) {
+  @internal
+  // ignore: avoid_setters_without_getters
+  set client(http.Client client) {
     _client = client;
   }
 
@@ -107,12 +131,12 @@ class API {
   RelyingpartyResource get identityToolkit {
     if (apiConfig.emulator != null) {
       return IdentityToolkitApi(
-        _client,
+        _client!,
         rootUrl: apiConfig.emulator!.rootUrl,
       ).relyingparty;
     }
     return IdentityToolkitApi(
-      _client,
+      _client!,
     ).relyingparty;
   }
 

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
@@ -37,28 +37,6 @@ part 'authentication/sms.dart';
 part 'authentication/token.dart';
 part 'emulator.dart';
 
-/// Response template to be returned from all sign in methods.
-abstract class SignInResponse {
-  /// Construct a new [SignInResponse].
-  SignInResponse(
-    this.idToken,
-    this.refreshToken, [
-    this.isNewUser = false,
-  ]);
-
-  /// User's Firebase Id Token.
-  final String idToken;
-
-  /// User's refresh token.
-  final String refreshToken;
-
-  /// Whether this user is new or not.
-  final bool isNewUser;
-
-  /// Map representation of this object.
-  Map<String, dynamic> toJson();
-}
-
 /// All API classes calling to IDP API must extend this template.
 abstract class APIDelegate {
   /// Construct a new [APIDelegate].
@@ -91,6 +69,56 @@ class APIConfig {
   }
 }
 
+/// Response template to be returned from all sign in methods.
+abstract class SignInResponse {
+  /// Construct a new [SignInResponse].
+  SignInResponse(
+    this.idToken,
+    this.refreshToken, [
+    this.isNewUser = false,
+  ]);
+
+  /// User's Firebase Id Token.
+  final String idToken;
+
+  /// User's refresh token.
+  final String refreshToken;
+
+  /// Whether this user is new or not.
+  final bool isNewUser;
+
+  /// Json representation of this object.
+  Map<String, dynamic> toJson() {
+    return {
+      'idToken': idToken,
+      'refreshToken': refreshToken,
+    };
+  }
+}
+
+/// A return type from Idp authentication requests, must be extended by any other response
+/// type for any operation that requires idToken.
+@protected
+abstract class IdTokenResponse {
+  /// Construct a new [IdTokenResponse].
+  const IdTokenResponse({required this.idToken, required this.refreshToken});
+
+  /// The idToken returned from a successful authentication operation, valid only for 1 hour.
+  final String idToken;
+
+  /// Th refreshToken returned from a successful authentication operation, used to request new
+  /// [idToken] if it has expired or force refreshed.
+  final String refreshToken;
+
+  /// Json representation of this object.
+  Map<String, dynamic> toJson() {
+    return {
+      'idToken': idToken,
+      'refreshToken': refreshToken,
+    };
+  }
+}
+
 /// Pure Dart service layer to perform all requests
 /// with the underlying Identity Toolkit API.
 ///
@@ -109,10 +137,10 @@ class API {
     );
   }
 
-  static final Map<APIConfig, API> _instances = {};
-
   /// The API configurations of this instance.
   final APIConfig apiConfig;
+
+  static final Map<APIConfig, API> _instances = {};
 
   http.Client? _client;
 
@@ -129,7 +157,7 @@ class API {
     _client = client;
   }
 
-  /// Updates the languageCode for this instance.
+  /// Updates the [languageCode] for this instance.
   void setLanguageCode(String? languageCode) {
     _languageCode = languageCode;
     requestHeaders.addAll({'X-Firebase-Locale': languageCode ?? ''});

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/api.dart
@@ -4,42 +4,38 @@
 
 // ignore_for_file: require_trailing_commas, avoid_dynamic_calls, use_setters_to_change_properties, implementation_imports
 
+library api;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:firebaseapis/identitytoolkit/v3.dart' as idp;
+import 'package:firebaseapis/identitytoolkit/v3.dart';
 import 'package:firebaseapis/src/user_agent.dart';
 import 'package:googleapis_auth/auth_io.dart'
     if (dart.library.html) 'package:googleapis_auth/auth_browser.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
-import '../../src/providers/email_auth.dart';
-import 'authentication/phone.dart';
+import '../firebase_auth_exception.dart';
+import '../providers/email_auth.dart';
+import '../utils/open_url.dart';
 
-/// A return type from Idp authentication requests, must be extended by any other response
-/// type for any operation that requires idToken.
-@protected
-class IdTokenResponse {
-  /// Construct a new [IdTokenResponse].
-  IdTokenResponse({required this.idToken, required this.refreshToken});
-
-  /// The idToken returned from a successful authentication operation, valid only for 1 hour.
-  final String idToken;
-
-  /// Th refreshToken returned from a successful authentication operation, used to request new
-  /// [idToken] if it has expired or force refreshed.
-  final String refreshToken;
-
-  /// Json representation of this object.
-  Map<String, dynamic> toJson() {
-    return {
-      'idToken': idToken,
-      'refreshToken': refreshToken,
-    };
-  }
-}
+part 'account_managament/account.dart';
+part 'account_managament/email_and_password.dart';
+part 'account_managament/profile.dart';
+part 'authentication/create_auth_uri.dart';
+part 'authentication/custom_token.dart';
+part 'authentication/email_and_password.dart';
+part 'authentication/idp.dart';
+part 'authentication/recaptcha/recaptcha_args.dart';
+part 'authentication/recaptcha/recaptcha_html.dart';
+part 'authentication/recaptcha/recaptcha_verification_server.dart';
+part 'authentication/recaptcha/recaptcha_verifier.dart';
+part 'authentication/sign_up.dart';
+part 'authentication/sms.dart';
+part 'authentication/token.dart';
+part 'emulator.dart';
 
 /// Configurations necessary for making all idp requests.
 @protected
@@ -70,10 +66,19 @@ class APIConfig {
 /// See: https://cloud.google.com/identity-platform/docs/use-rest-api
 @protected
 class API {
-  // ignore: public_member_api_docs
-  API(this.apiConfig, {http.Client? client}) {
+  API._(this.apiConfig, {http.Client? client}) {
     _client = client ?? clientViaApiKey(apiConfig.apiKey);
   }
+
+  /// Construct new or existing [API] instance for a given [APIConfig].
+  factory API.instanceOf(APIConfig apiConfig, {http.Client? client}) {
+    return _instances.putIfAbsent(
+      apiConfig,
+      () => API._(apiConfig, client: client),
+    );
+  }
+
+  static final Map<APIConfig, API> _instances = {};
 
   /// The API configurations of this instance.
   final APIConfig apiConfig;
@@ -97,361 +102,59 @@ class API {
     requestHeaders.addAll({'X-Firebase-Locale': languageCode ?? ''});
   }
 
-  /// Identity platform [idp.RelyingpartyResource] initialized with this instance [APIConfig].
+  /// Identity platform [RelyingpartyResource] initialized with this instance [APIConfig].
   @internal
-  idp.RelyingpartyResource get identityToolkit {
+  RelyingpartyResource get identityToolkit {
     if (apiConfig.emulator != null) {
-      return idp.IdentityToolkitApi(
+      return IdentityToolkitApi(
         _client,
         rootUrl: apiConfig.emulator!.rootUrl,
       ).relyingparty;
     }
-    return idp.IdentityToolkitApi(
+    return IdentityToolkitApi(
       _client,
     ).relyingparty;
   }
 
-  PhoneAuthAPI? _phoneAuthApiDelegate;
+  /// A delegate getter used to perform all requests
+  /// for email and password authentication related operations.
+  EmailAndPasswordAuth get emailAndPasswordAuth => EmailAndPasswordAuth(this);
 
   /// A delegate used to perform all requests for phone authentication.
-  ///
-  /// Will lazily be initialized on first call.
-  PhoneAuthAPI get phoneAuthApiDelegate =>
-      _phoneAuthApiDelegate ??= PhoneAuthAPI(this);
+  SmsAuth get smsAuth => SmsAuth(this);
 
-  /// TODO: write endpoint details
-  Future<idp.VerifyPasswordResponse> signInWithEmailAndPassword(
-      String email, String password) async {
-    final _response = await identityToolkit.verifyPassword(
-      idp.IdentitytoolkitRelyingpartyVerifyPasswordRequest(
-        returnSecureToken: true,
-        password: password,
-        email: email,
-      ),
-    );
+  /// A delegate getter used to perform all requests
+  /// for sign-up related operations.
+  SignUp get signUp => SignUp(this);
 
-    return _response;
-  }
+  /// A delegate getter used to perform all requests
+  /// for custon token related operations.
+  CustomTokenAuth get customTokenAuth => CustomTokenAuth(this);
 
-  /// TODO: write endpoint details
-  Future<idp.SignupNewUserResponse> createUserWithEmailAndPassword(
-      String email, String password) async {
-    final _response = await identityToolkit.signupNewUser(
-      idp.IdentitytoolkitRelyingpartySignupNewUserRequest(
-        email: email,
-        password: password,
-      ),
-    );
-    return _response;
-  }
+  /// A delegate getter used to perform all requests
+  /// for Identity platform sign-in related operations.
+  IdpAuth get idpAuth => IdpAuth(this);
 
-  /// TODO: write endpoint details
-  Future<idp.SignupNewUserResponse> signInAnonymously() async {
-    final _response = await identityToolkit.signupNewUser(
-      idp.IdentitytoolkitRelyingpartySignupNewUserRequest(),
-    );
+  /// All methods calling `createAuthUri` endpoint.
+  CreateAuthUri get createAuthUri => CreateAuthUri(this);
 
-    return _response;
-  }
+  /// A delegate used to perform all requests for account-related operations.
+  UserAccount get userAccount => UserAccount(this);
 
-  /// TODO: write endpoint details
-  Future<idp.VerifyAssertionResponse> signInWithOAuthCredential({
-    required String providerId,
-    String? idToken,
-    String? requestUri,
-    String? providerIdToken,
-    String? providerAccessToken,
-    String? providerSecret,
-  }) async {
-    var uri = Uri.parse(requestUri ?? '');
-    if (!uri.isScheme('https')) {
-      uri = uri.replace(scheme: 'https');
-    }
+  /// A delegate getter used to perform all requests
+  /// for token related operations.
+  IdToken get idToken => IdToken(this);
 
-    final postBody = <String>['providerId=$providerId'];
+  /// A delegate getter used to perform all requests
+  /// for email and password account related operations.
+  EmailAndPasswordAccount get emailAndPasswordAccount =>
+      EmailAndPasswordAccount(this);
 
-    if (providerIdToken != null) {
-      postBody.add('id_token=$providerIdToken');
-    }
-    if (providerAccessToken != null) {
-      postBody.add('access_token=$providerAccessToken');
-    }
-    if (providerSecret != null) {
-      postBody.add('oauth_token_secret=$providerSecret');
-    }
+  /// A delegate getter used to perform all requests
+  /// for Identity platform profile related operations.
+  UserProfile get userProfile => UserProfile(this);
 
-    final response = await identityToolkit.verifyAssertion(
-      idp.IdentitytoolkitRelyingpartyVerifyAssertionRequest(
-        idToken: idToken,
-        requestUri: uri.toString(),
-        postBody: postBody.join('&'),
-        returnIdpCredential: true,
-        returnSecureToken: true,
-      ),
-    );
-
-    if (response.errorMessage != null) {
-      throw idp.DetailedApiRequestError(null, response.errorMessage);
-    }
-
-    return response;
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.VerifyCustomTokenResponse> signInWithCustomToken(
-      String token) async {
-    final response = await identityToolkit.verifyCustomToken(
-      idp.IdentitytoolkitRelyingpartyVerifyCustomTokenRequest(
-        token: token,
-        returnSecureToken: true,
-      ),
-    );
-
-    return response;
-  }
-
-  /// TODO: write endpoint details
-  Future<List<String>> fetchSignInMethodsForEmail(String email) async {
-    final _response = await identityToolkit.createAuthUri(
-      idp.IdentitytoolkitRelyingpartyCreateAuthUriRequest(
-        identifier: email,
-        // TODO hmm?
-        continueUri: 'http://localhost:8080/app',
-      ),
-    );
-
-    return _response.allProviders ?? [];
-  }
-
-  /// TODO: write endpoint details
-  Future<String> sendPasswordResetEmail(String email,
-      {String? continueUrl}) async {
-    final _response = await identityToolkit.getOobConfirmationCode(
-      idp.Relyingparty(
-        email: email,
-        requestType: 'PASSWORD_RESET',
-        continueUrl: continueUrl,
-      ),
-    );
-
-    return _response.email!;
-  }
-
-  /// TODO: write endpoint details
-  Future<String> confirmPasswordReset(String? code, String? newPassword) async {
-    final _response = await identityToolkit.resetPassword(
-      idp.IdentitytoolkitRelyingpartyResetPasswordRequest(
-        newPassword: newPassword,
-        oobCode: code,
-      ),
-    );
-
-    return _response.email!;
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.SetAccountInfoResponse> resetUserPassword(String idToken,
-      {String? newPassword}) async {
-    return identityToolkit.setAccountInfo(
-      idp.IdentitytoolkitRelyingpartySetAccountInfoRequest(
-        idToken: idToken,
-        password: newPassword,
-      ),
-    );
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.GetOobConfirmationCodeResponse> sendSignInLinkToEmail(
-      String email, String? continueUrl) async {
-    return identityToolkit.getOobConfirmationCode(
-      idp.Relyingparty(
-        email: email,
-        requestType: 'EMAIL_SIGNIN',
-        // have to be sent, otherwise the user won't be redirected to the app.
-        continueUrl: continueUrl,
-      ),
-    );
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.SetAccountInfoResponse> updateEmail(
-      String newEmail, String idToken, String uid) async {
-    final _response = await identityToolkit.setAccountInfo(
-      idp.IdentitytoolkitRelyingpartySetAccountInfoRequest(
-        email: newEmail,
-        idToken: idToken,
-        localId: uid,
-      ),
-    );
-    return _response;
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.SetAccountInfoResponse> updateProfile(
-    String idToken,
-    String uid, {
-    String? photoUrl = '',
-    String? displayName = '',
-  }) async {
-    final _response = await identityToolkit.setAccountInfo(
-      idp.IdentitytoolkitRelyingpartySetAccountInfoRequest(
-        displayName: displayName == '' ? null : displayName,
-        photoUrl: photoUrl == '' ? null : photoUrl,
-        idToken: idToken,
-        localId: uid,
-        returnSecureToken: true,
-        deleteAttribute: [
-          if (photoUrl == null) 'PHOTO_URL',
-          if (displayName == null) 'DISPLAY_NAME'
-        ],
-      ),
-    );
-    return _response;
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.SetAccountInfoResponse> updatePassword(
-      String newPassword, String idToken) async {
-    final _response = await identityToolkit.setAccountInfo(
-      idp.IdentitytoolkitRelyingpartySetAccountInfoRequest(
-        idToken: idToken,
-        password: newPassword,
-      ),
-    );
-    return _response;
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.SetAccountInfoResponse> linkWithEmail(String idToken,
-      {required EmailAuthCredential credential}) async {
-    return identityToolkit.setAccountInfo(
-      idp.IdentitytoolkitRelyingpartySetAccountInfoRequest(
-        idToken: idToken,
-        email: credential.email,
-        password: credential.password,
-      ),
-    );
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.SetAccountInfoResponse> unlink(
-      String idToken, String providerId) async {
-    return identityToolkit.setAccountInfo(
-      idp.IdentitytoolkitRelyingpartySetAccountInfoRequest(
-        idToken: idToken,
-        deleteProvider: [providerId],
-      ),
-    );
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.UserInfo> getCurrentUser(String? idToken) async {
-    final _response = await identityToolkit.getAccountInfo(
-      idp.IdentitytoolkitRelyingpartyGetAccountInfoRequest(idToken: idToken),
-    );
-
-    return _response.users![0];
-  }
-
-  /// TODO: write endpoint details
-  Future<String?> sendEmailVerification(String idToken) async {
-    final _response = await identityToolkit.getOobConfirmationCode(
-      idp.Relyingparty(requestType: 'VERIFY_EMAIL', idToken: idToken),
-    );
-
-    return _response.email;
-  }
-
-  /// Refresh a user ID token using the refreshToken,
-  /// will refresh even if the token hasn't expired.
-  ///
-  Future<String?> refreshIdToken(String? refreshToken) async {
-    try {
-      return await _exchangeRefreshWithIdToken(refreshToken);
-    } on HttpException catch (_) {
-      rethrow;
-    } catch (_) {
-      rethrow;
-    }
-  }
-
-  Future<String?> _exchangeRefreshWithIdToken(String? refreshToken) async {
-    final baseUri = apiConfig.emulator != null
-        ? 'http://${apiConfig.emulator!.host}:${apiConfig.emulator!.port}/securetoken.googleapis.com/v1/'
-        : 'https://securetoken.googleapis.com/v1/';
-
-    final _response = await http.post(
-      Uri.parse(
-        '${baseUri}token?key=${apiConfig.apiKey}',
-      ),
-      body: {
-        'grant_type': 'refresh_token',
-        'refresh_token': refreshToken,
-      },
-      headers: {'Content-Typ': 'application/json'},
-    );
-
-    final Map<String, dynamic> _data = json.decode(_response.body);
-
-    return _data['access_token'];
-  }
-
-  /// TODO: write endpoint details
-  Future<idp.DeleteAccountResponse> delete(String idToken, String uid) async {
-    return identityToolkit.deleteAccount(
-      idp.IdentitytoolkitRelyingpartyDeleteAccountRequest(
-        idToken: idToken,
-        localId: uid,
-      ),
-    );
-  }
-
-  /// TODO: write endpoint details
-  Future<Map> useEmulator(String host, int port) async {
-    // 1. Get the emulator project configs, it must be initialized first.
-    // http://localhost:9099/emulator/v1/projects/{project-id}/config
-    final localEmulator = Uri(
-      scheme: 'http',
-      host: host,
-      port: port,
-      path: '/emulator/v1/projects/${apiConfig.projectId}/config',
-    );
-
-    http.Response response;
-
-    try {
-      response = await http.get(localEmulator);
-    } catch (e) {
-      return {};
-    }
-
-    final Map emulatorProjectConfig = json.decode(response.body);
-
-    // set the the emulator config for this instance.
-    apiConfig.setEmulator(host, port);
-
-    return emulatorProjectConfig;
-  }
-}
-
-/// A type to hold the Auth Emulator configurations.
-class EmulatorConfig {
-  EmulatorConfig._({
-    required this.port,
-    required this.host,
-  });
-
-  /// Initialize the Emulator Config using the host and port printed once running `firebase emulators:start`.
-  factory EmulatorConfig.use(String host, int port) {
-    return EmulatorConfig._(port: port, host: host);
-  }
-
-  /// The port on which the emulator suite is running.
-  final String host;
-
-  /// The port on which the emulator suite is running.
-  final int port;
-
-  /// The root URL used to make requests to the locally running emulator.
-  String get rootUrl => 'http://$host:$port/www.googleapis.com/';
+  /// A delegate getter used to perform all requests
+  /// for Identity platform profile related operations.
+  AuthEmulator get emulator => AuthEmulator(apiConfig);
 }

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/create_auth_uri.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/create_auth_uri.dart
@@ -1,0 +1,33 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `createAuthUri`:  look all providers associated with a specified email.
+@internal
+class CreateAuthUri {
+  // ignore: public_member_api_docs
+  CreateAuthUri(this._api);
+
+  final API _api;
+
+  /// Look all providers associated with a specified email.
+  /// Returns a list of provider Ids.
+  ///
+  /// Example response:
+  /// ```dart
+  /// ["password", "google.com"]
+  /// ```
+  ///
+  /// Common error codes:
+  /// - `INVALID_EMAIL`: The email address is badly formatted.
+  Future<List<String>> fetchSignInMethodsForEmail(String email) async {
+    final _response = await _api.identityToolkit.createAuthUri(
+      IdentitytoolkitRelyingpartyCreateAuthUriRequest(
+        identifier: email,
+        // TODO hmm?
+        continueUri: 'http://localhost:8080/app',
+      ),
+    );
+
+    return _response.allProviders ?? [];
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/create_auth_uri.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/create_auth_uri.dart
@@ -9,7 +9,7 @@ class CreateAuthUri {
 
   final API _api;
 
-  /// Look all providers associated with a specified email.
+  /// Look up all providers associated with an email.
   /// Returns a list of provider Ids.
   ///
   /// Example response:
@@ -19,15 +19,17 @@ class CreateAuthUri {
   ///
   /// Common error codes:
   /// - `INVALID_EMAIL`: The email address is badly formatted.
-  Future<List<String>> fetchSignInMethodsForEmail(String email) async {
+  Future<List<String>> fetchSignInMethodsForEmail(
+    String email, {
+    String? continueUri = 'http://localhost',
+  }) async {
     final _response = await _api.identityToolkit.createAuthUri(
       IdentitytoolkitRelyingpartyCreateAuthUriRequest(
         identifier: email,
-        // TODO hmm?
-        continueUri: 'http://localhost:8080/app',
+        continueUri: continueUri,
       ),
     );
 
-    return _response.allProviders ?? [];
+    return _response.signinMethods ?? [];
   }
 }

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/create_auth_uri.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/create_auth_uri.dart
@@ -3,11 +3,9 @@ part of api;
 /// Class wrapping methods that calls to the following endpoints:
 /// - `createAuthUri`:  look all providers associated with a specified email.
 @internal
-class CreateAuthUri {
+class CreateAuthUri extends APIDelegate {
   // ignore: public_member_api_docs
-  CreateAuthUri(this._api);
-
-  final API _api;
+  const CreateAuthUri(API api) : super(api);
 
   /// Look up all providers associated with an email.
   /// Returns a list of provider Ids.
@@ -23,7 +21,7 @@ class CreateAuthUri {
     String email, {
     String? continueUri = 'http://localhost',
   }) async {
-    final _response = await _api.identityToolkit.createAuthUri(
+    final _response = await api.identityToolkit.createAuthUri(
       IdentitytoolkitRelyingpartyCreateAuthUriRequest(
         identifier: email,
         continueUri: continueUri,

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
@@ -1,0 +1,23 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `verifyCustomToken`: exchange a custom Auth token for an ID and refresh token.
+@internal
+class CustomTokenAuth {
+  // ignore: public_member_api_docs
+  CustomTokenAuth(this._api);
+
+  final API _api;
+
+  /// TODO: write endpoint details
+  Future<VerifyCustomTokenResponse> signInWithCustomToken(String token) async {
+    final response = await _api.identityToolkit.verifyCustomToken(
+      IdentitytoolkitRelyingpartyVerifyCustomTokenRequest(
+        token: token,
+        returnSecureToken: true,
+      ),
+    );
+
+    return response;
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
@@ -31,11 +31,9 @@ class CustomTokenResponse extends SignInResponse {
 /// Class wrapping methods that calls to the following endpoints:
 /// - `verifyCustomToken`: exchange a custom Auth token for a `tokenId` and `refreshToken`.
 @internal
-class CustomTokenAuth {
+class CustomTokenAuth extends APIDelegate {
   // ignore: public_member_api_docs
-  CustomTokenAuth(this._api);
-
-  final API _api;
+  const CustomTokenAuth(API api) : super(api);
 
   /// Sign a user using developer's custom JWT token.
   /// The response will contain a fresh `idToken` and a `refreshToken`.
@@ -45,7 +43,7 @@ class CustomTokenAuth {
   /// invalid for some reason (e.g. expired, invalid signature etc.)
   /// - `CREDENTIAL_MISMATCH`: The custom token corresponds to a different Firebase project.
   Future<CustomTokenResponse> signInWithCustomToken(String customToken) async {
-    final response = await _api.identityToolkit.verifyCustomToken(
+    final response = await api.identityToolkit.verifyCustomToken(
       IdentitytoolkitRelyingpartyVerifyCustomTokenRequest(
         token: customToken,
         returnSecureToken: true,

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
@@ -1,7 +1,35 @@
 part of api;
 
+/// A response parsed from `verifyCustomToken` endpoint result.
+@internal
+class CustomTokenResponse extends SignInResponse {
+  CustomTokenResponse._({
+    required String idToken,
+    required String refreshToken,
+    bool isNewUser = false,
+  }) : super(idToken, refreshToken, isNewUser);
+
+  /// Construct new [CustomTokenResponse] from a sign-in json result.
+  factory CustomTokenResponse.fromJson(Map<String, dynamic> json) {
+    return CustomTokenResponse._(
+      idToken: json['idToken'] as String,
+      refreshToken: json['refreshToken'] as String,
+      isNewUser: (json['isNewUser'] as bool?) ?? false,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'idToken': idToken,
+      'refreshToken': refreshToken,
+      'isNewUser': isNewUser,
+    };
+  }
+}
+
 /// Class wrapping methods that calls to the following endpoints:
-/// - `verifyCustomToken`: exchange a custom Auth token for an ID and refresh token.
+/// - `verifyCustomToken`: exchange a custom Auth token for a `tokenId` and `refreshToken`.
 @internal
 class CustomTokenAuth {
   // ignore: public_member_api_docs
@@ -9,15 +37,21 @@ class CustomTokenAuth {
 
   final API _api;
 
-  /// TODO: write endpoint details
-  Future<VerifyCustomTokenResponse> signInWithCustomToken(String token) async {
+  /// Sign a user using developer's custom JWT token.
+  /// The response will contain a fresh `idToken` and a `refreshToken`.
+  ///
+  /// Common error codes:
+  /// - `INVALID_CUSTOM_TOKEN`: The custom token format is incorrect or the token is
+  /// invalid for some reason (e.g. expired, invalid signature etc.)
+  /// - `CREDENTIAL_MISMATCH`: The custom token corresponds to a different Firebase project.
+  Future<CustomTokenResponse> signInWithCustomToken(String customToken) async {
     final response = await _api.identityToolkit.verifyCustomToken(
       IdentitytoolkitRelyingpartyVerifyCustomTokenRequest(
-        token: token,
+        token: customToken,
         returnSecureToken: true,
       ),
     );
 
-    return response;
+    return CustomTokenResponse.fromJson(response.toJson());
   }
 }

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/custom_token.dart
@@ -21,8 +21,7 @@ class CustomTokenResponse extends SignInResponse {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'idToken': idToken,
-      'refreshToken': refreshToken,
+      ...super.toJson(),
       'isNewUser': isNewUser,
     };
   }

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/email_and_password.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/email_and_password.dart
@@ -11,7 +11,13 @@ class EmailAndPasswordAuth extends APIDelegate {
   // ignore: public_member_api_docs
   const EmailAndPasswordAuth(API api) : super(api);
 
-  /// TODO: write endpoint details
+  /// Sign in a user with an email and password.
+  ///
+  /// Common error codes:
+  /// - `EMAIL_NOT_FOUND`: There is no user record corresponding to this identifier.
+  /// The user may have been deleted.
+  /// - `INVALID_PASSWORD`: The password is invalid or the user does not have a password.
+  /// - `USER_DISABLED`: The user account has been disabled by an administrator.
   Future<VerifyPasswordResponse> signInWithEmailAndPassword(
     String email,
     String password,
@@ -27,7 +33,13 @@ class EmailAndPasswordAuth extends APIDelegate {
     return _response;
   }
 
-  /// TODO: write endpoint details
+  /// Create a new email and password user.
+  ///
+  /// Common error codes:
+  /// - `EMAIL_EXISTS`: The email address is already in use by another account.
+  /// - `OPERATION_NOT_ALLOWED`: Password sign-in is disabled for this project.
+  /// - `TOO_MANY_ATTEMPTS_TRY_LATER`: We have blocked all requests from this
+  /// device due to unusual activity. Try again later.
   Future<SignupNewUserResponse> createUserWithEmailAndPassword(
     String email,
     String password,
@@ -41,7 +53,13 @@ class EmailAndPasswordAuth extends APIDelegate {
     return _response;
   }
 
-  /// TODO: write endpoint details
+  /// Link an email/password to a current user.
+  ///
+  /// Common error codes:
+  /// - `CREDENTIAL_TOO_OLD_LOGIN_AGAIN`: The user's credential is no longer valid. The user must sign in again.
+  /// - `TOKEN_EXPIRED`: The user's credential is no longer valid. The user must sign in again.
+  /// - `INVALID_ID_TOKEN`:The user's credential is no longer valid. The user must sign in again.
+  /// - `WEAK_PASSWORD`: The password must be 6 characters long or more.
   Future<SetAccountInfoResponse> linkWithEmail(
     String idToken, {
     required EmailAuthCredential credential,
@@ -55,7 +73,12 @@ class EmailAndPasswordAuth extends APIDelegate {
     );
   }
 
-  /// TODO: write endpoint details
+  /// Send an email verification for the current user.
+  ///
+  /// Common error codes:
+  /// - `INVALID_ID_TOKEN`: The user's credential is no longer valid. The user must sign in again.
+  /// - `USER_NOT_FOUND`: There is no user record corresponding to this identifier.
+  /// The user may have been deleted.
   Future<String?> sendVerificationEmail(String idToken) async {
     final _response = await api.identityToolkit.getOobConfirmationCode(
       Relyingparty(requestType: 'VERIFY_EMAIL', idToken: idToken),
@@ -64,7 +87,11 @@ class EmailAndPasswordAuth extends APIDelegate {
     return _response.email;
   }
 
-  /// TODO: write endpoint details
+  /// Send a password reset email.
+  ///
+  /// Common error codes:
+  /// - `EMAIL_NOT_FOUND`: There is no user record corresponding to this identifier.
+  /// The user may have been deleted.
   Future<String> sendPasswordResetEmail(
     String email, {
     String? continueUrl,
@@ -78,20 +105,5 @@ class EmailAndPasswordAuth extends APIDelegate {
     );
 
     return _response.email!;
-  }
-
-  /// TODO: write endpoint details
-  Future<GetOobConfirmationCodeResponse> sendSignInLinkToEmail(
-    String email,
-    String? continueUrl,
-  ) async {
-    return api.identityToolkit.getOobConfirmationCode(
-      Relyingparty(
-        email: email,
-        requestType: 'EMAIL_SIGNIN',
-        // have to be sent, otherwise the user won't be redirected to the app.
-        continueUrl: continueUrl,
-      ),
-    );
   }
 }

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/email_and_password.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/email_and_password.dart
@@ -7,18 +7,16 @@ part of api;
 /// - `getOobConfirmationCode`: send an email verification for the current user
 /// or send a password reset email.
 @internal
-class EmailAndPasswordAuth {
+class EmailAndPasswordAuth extends APIDelegate {
   // ignore: public_member_api_docs
-  const EmailAndPasswordAuth(this._api);
-
-  final API _api;
+  const EmailAndPasswordAuth(API api) : super(api);
 
   /// TODO: write endpoint details
   Future<VerifyPasswordResponse> signInWithEmailAndPassword(
     String email,
     String password,
   ) async {
-    final _response = await _api.identityToolkit.verifyPassword(
+    final _response = await api.identityToolkit.verifyPassword(
       IdentitytoolkitRelyingpartyVerifyPasswordRequest(
         returnSecureToken: true,
         password: password,
@@ -34,7 +32,7 @@ class EmailAndPasswordAuth {
     String email,
     String password,
   ) async {
-    final _response = await _api.identityToolkit.signupNewUser(
+    final _response = await api.identityToolkit.signupNewUser(
       IdentitytoolkitRelyingpartySignupNewUserRequest(
         email: email,
         password: password,
@@ -48,7 +46,7 @@ class EmailAndPasswordAuth {
     String idToken, {
     required EmailAuthCredential credential,
   }) async {
-    return _api.identityToolkit.setAccountInfo(
+    return api.identityToolkit.setAccountInfo(
       IdentitytoolkitRelyingpartySetAccountInfoRequest(
         idToken: idToken,
         email: credential.email,
@@ -59,7 +57,7 @@ class EmailAndPasswordAuth {
 
   /// TODO: write endpoint details
   Future<String?> sendVerificationEmail(String idToken) async {
-    final _response = await _api.identityToolkit.getOobConfirmationCode(
+    final _response = await api.identityToolkit.getOobConfirmationCode(
       Relyingparty(requestType: 'VERIFY_EMAIL', idToken: idToken),
     );
 
@@ -71,7 +69,7 @@ class EmailAndPasswordAuth {
     String email, {
     String? continueUrl,
   }) async {
-    final _response = await _api.identityToolkit.getOobConfirmationCode(
+    final _response = await api.identityToolkit.getOobConfirmationCode(
       Relyingparty(
         email: email,
         requestType: 'PASSWORD_RESET',
@@ -87,7 +85,7 @@ class EmailAndPasswordAuth {
     String email,
     String? continueUrl,
   ) async {
-    return _api.identityToolkit.getOobConfirmationCode(
+    return api.identityToolkit.getOobConfirmationCode(
       Relyingparty(
         email: email,
         requestType: 'EMAIL_SIGNIN',

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/email_and_password.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/email_and_password.dart
@@ -1,0 +1,99 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `verifyPassword`: sign in a user with an email and password.
+/// - `signupNewUser`: create a new email and password user.
+/// - `setAccountInfo`: change user account info based on request parameters.
+/// - `getOobConfirmationCode`: send an email verification for the current user
+/// or send a password reset email.
+@internal
+class EmailAndPasswordAuth {
+  // ignore: public_member_api_docs
+  const EmailAndPasswordAuth(this._api);
+
+  final API _api;
+
+  /// TODO: write endpoint details
+  Future<VerifyPasswordResponse> signInWithEmailAndPassword(
+    String email,
+    String password,
+  ) async {
+    final _response = await _api.identityToolkit.verifyPassword(
+      IdentitytoolkitRelyingpartyVerifyPasswordRequest(
+        returnSecureToken: true,
+        password: password,
+        email: email,
+      ),
+    );
+
+    return _response;
+  }
+
+  /// TODO: write endpoint details
+  Future<SignupNewUserResponse> createUserWithEmailAndPassword(
+    String email,
+    String password,
+  ) async {
+    final _response = await _api.identityToolkit.signupNewUser(
+      IdentitytoolkitRelyingpartySignupNewUserRequest(
+        email: email,
+        password: password,
+      ),
+    );
+    return _response;
+  }
+
+  /// TODO: write endpoint details
+  Future<SetAccountInfoResponse> linkWithEmail(
+    String idToken, {
+    required EmailAuthCredential credential,
+  }) async {
+    return _api.identityToolkit.setAccountInfo(
+      IdentitytoolkitRelyingpartySetAccountInfoRequest(
+        idToken: idToken,
+        email: credential.email,
+        password: credential.password,
+      ),
+    );
+  }
+
+  /// TODO: write endpoint details
+  Future<String?> sendVerificationEmail(String idToken) async {
+    final _response = await _api.identityToolkit.getOobConfirmationCode(
+      Relyingparty(requestType: 'VERIFY_EMAIL', idToken: idToken),
+    );
+
+    return _response.email;
+  }
+
+  /// TODO: write endpoint details
+  Future<String> sendPasswordResetEmail(
+    String email, {
+    String? continueUrl,
+  }) async {
+    final _response = await _api.identityToolkit.getOobConfirmationCode(
+      Relyingparty(
+        email: email,
+        requestType: 'PASSWORD_RESET',
+        continueUrl: continueUrl,
+      ),
+    );
+
+    return _response.email!;
+  }
+
+  /// TODO: write endpoint details
+  Future<GetOobConfirmationCodeResponse> sendSignInLinkToEmail(
+    String email,
+    String? continueUrl,
+  ) async {
+    return _api.identityToolkit.getOobConfirmationCode(
+      Relyingparty(
+        email: email,
+        requestType: 'EMAIL_SIGNIN',
+        // have to be sent, otherwise the user won't be redirected to the app.
+        continueUrl: continueUrl,
+      ),
+    );
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/idp.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/idp.dart
@@ -1,0 +1,54 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `verifyAssertion`: sign in or link a user with an OAuth credential.
+@internal
+class IdpAuth {
+  // ignore: public_member_api_docs
+  const IdpAuth(this._api);
+
+  final API _api;
+
+  /// TODO: write endpoint details
+  Future<VerifyAssertionResponse> signInWithOAuthCredential({
+    required String providerId,
+    String? idToken,
+    String? requestUri,
+    String? providerIdToken,
+    String? providerAccessToken,
+    String? providerSecret,
+  }) async {
+    var uri = Uri.parse(requestUri ?? '');
+    if (!uri.isScheme('https')) {
+      uri = uri.replace(scheme: 'https');
+    }
+
+    final postBody = <String>['providerId=$providerId'];
+
+    if (providerIdToken != null) {
+      postBody.add('id_token=$providerIdToken');
+    }
+    if (providerAccessToken != null) {
+      postBody.add('access_token=$providerAccessToken');
+    }
+    if (providerSecret != null) {
+      postBody.add('oauth_token_secret=$providerSecret');
+    }
+
+    final response = await _api.identityToolkit.verifyAssertion(
+      IdentitytoolkitRelyingpartyVerifyAssertionRequest(
+        idToken: idToken,
+        requestUri: uri.toString(),
+        postBody: postBody.join('&'),
+        returnIdpCredential: true,
+        returnSecureToken: true,
+      ),
+    );
+
+    if (response.errorMessage != null) {
+      throw DetailedApiRequestError(null, response.errorMessage);
+    }
+
+    return response;
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/idp.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/idp.dart
@@ -7,7 +7,11 @@ class IdpAuth extends APIDelegate {
   // ignore: public_member_api_docs
   const IdpAuth(API api) : super(api);
 
-  /// TODO: write endpoint details
+  /// Sign in a user with an OAuth credential.
+  ///
+  /// Common error codes:
+  /// - `OPERATION_NOT_ALLOWED`: The corresponding provider is disabled for this project.
+  /// - `INVALID_IDP_RESPONSE`: The supplied auth credential is malformed or has expired.
   Future<VerifyAssertionResponse> signInWithOAuthCredential({
     required String providerId,
     String? idToken,

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/idp.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/idp.dart
@@ -3,11 +3,9 @@ part of api;
 /// Class wrapping methods that calls to the following endpoints:
 /// - `verifyAssertion`: sign in or link a user with an OAuth credential.
 @internal
-class IdpAuth {
+class IdpAuth extends APIDelegate {
   // ignore: public_member_api_docs
-  const IdpAuth(this._api);
-
-  final API _api;
+  const IdpAuth(API api) : super(api);
 
   /// TODO: write endpoint details
   Future<VerifyAssertionResponse> signInWithOAuthCredential({
@@ -35,7 +33,7 @@ class IdpAuth {
       postBody.add('oauth_token_secret=$providerSecret');
     }
 
-    final response = await _api.identityToolkit.verifyAssertion(
+    final response = await api.identityToolkit.verifyAssertion(
       IdentitytoolkitRelyingpartyVerifyAssertionRequest(
         idToken: idToken,
         requestUri: uri.toString(),

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_args.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_args.dart
@@ -1,3 +1,5 @@
+part of api;
+
 /// Recaptcha verification arguments needed to render recaptcha widget.
 class RecaptchaArgs {
   /// Construct new RecaptchaArgs.

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_html.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_html.dart
@@ -4,6 +4,8 @@
 
 // ignore_for_file: public_member_api_docs, require_trailing_commas
 
+part of api;
+
 String recaptchaHTML(String? siteKey, String? token,
     {String? theme, String? size}) {
   return '''

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_verification_server.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_verification_server.dart
@@ -1,8 +1,4 @@
-import 'dart:async';
-import 'dart:io';
-
-import 'recaptcha_args.dart';
-import 'recaptcha_html.dart';
+part of api;
 
 /// Request recaptcha verification on the local server.
 class RecaptchaVerificationServer {

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_verifier.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/recaptcha/recaptcha_verifier.dart
@@ -2,12 +2,7 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:io';
-
-import '../../../utils/open_url.dart';
-import 'recaptcha_args.dart';
-import 'recaptcha_verification_server.dart';
+part of api;
 
 /// The theme of the rendered recaptcha widget.
 enum RecaptchaTheme {

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sign_up.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sign_up.dart
@@ -7,7 +7,10 @@ class SignUp extends APIDelegate {
   // ignore: public_member_api_docs
   SignUp(API api) : super(api);
 
-  /// TODO: write endpoint details
+  /// Sign in a user anonymously.
+  ///
+  /// Common error codes:
+  /// - `OPERATION_NOT_ALLOWED`: Anonymous user sign-in is disabled for this project.
   Future<SignupNewUserResponse> signInAnonymously() async {
     final _response = await api.identityToolkit.signupNewUser(
       IdentitytoolkitRelyingpartySignupNewUserRequest(),

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sign_up.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sign_up.dart
@@ -1,0 +1,20 @@
+part of api;
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `signupNewUser`: sign in a user anonymously.
+@internal
+class SignUp {
+  // ignore: public_member_api_docs
+  SignUp(this._api);
+
+  final API _api;
+
+  /// TODO: write endpoint details
+  Future<SignupNewUserResponse> signInAnonymously() async {
+    final _response = await _api.identityToolkit.signupNewUser(
+      IdentitytoolkitRelyingpartySignupNewUserRequest(),
+    );
+
+    return _response;
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sign_up.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sign_up.dart
@@ -3,15 +3,13 @@ part of api;
 /// Class wrapping methods that calls to the following endpoints:
 /// - `signupNewUser`: sign in a user anonymously.
 @internal
-class SignUp {
+class SignUp extends APIDelegate {
   // ignore: public_member_api_docs
-  SignUp(this._api);
-
-  final API _api;
+  SignUp(API api) : super(api);
 
   /// TODO: write endpoint details
   Future<SignupNewUserResponse> signInAnonymously() async {
-    final _response = await _api.identityToolkit.signupNewUser(
+    final _response = await api.identityToolkit.signupNewUser(
       IdentitytoolkitRelyingpartySignupNewUserRequest(),
     );
 

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sms.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sms.dart
@@ -1,13 +1,6 @@
 // ignore_for_file: require_trailing_commas
-import 'dart:async';
 
-import 'package:firebaseapis/identitytoolkit/v3.dart' as idp;
-import 'package:meta/meta.dart';
-
-import '../../firebase_auth_exception.dart';
-import '../api.dart';
-import 'recaptcha/recaptcha_args.dart';
-import 'recaptcha/recaptcha_verifier.dart';
+part of api;
 
 /// A return type from Idp phone authentication requests.
 @internal
@@ -48,11 +41,13 @@ class SignInWithPhoneNumberResponse {
   }
 }
 
-/// The instance used for phone authentication with idp.
+/// Class wrapping methods that calls to the following endpoints:
+/// - `verifyPhoneNumber`: verify a phone number using a verification id and sms code.
+/// - `sendVerificationCode`: send an sms login code.
 @internal
-class PhoneAuthAPI {
-  /// Construct a new [PhoneAuthAPI].
-  PhoneAuthAPI(this._api);
+class SmsAuth {
+  /// Construct a new [SmsAuth].
+  SmsAuth(this._api);
 
   /// The [API] instance containing required configurations to make the requests.
   final API _api;
@@ -116,7 +111,7 @@ class PhoneAuthAPI {
   }) async {
     try {
       final response = await _api.identityToolkit.verifyPhoneNumber(
-        idp.IdentitytoolkitRelyingpartyVerifyPhoneNumberRequest(
+        IdentitytoolkitRelyingpartyVerifyPhoneNumberRequest(
           code: smsCode,
           sessionInfo: verificationId,
           idToken: idToken,
@@ -188,7 +183,7 @@ class PhoneAuthAPI {
     try {
       // Send SMS code.
       final response = await _api.identityToolkit.sendVerificationCode(
-        idp.IdentitytoolkitRelyingpartySendVerificationCodeRequest(
+        IdentitytoolkitRelyingpartySendVerificationCodeRequest(
           phoneNumber: phoneNumber,
           recaptchaToken: recaptchaToken,
         ),

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sms.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/sms.dart
@@ -55,12 +55,9 @@ class SignInWithPhoneNumberResponse extends SignInResponse {
 /// - `verifyPhoneNumber`: verify a phone number using a verification id and sms code.
 /// - `sendVerificationCode`: send an sms login code.
 @internal
-class SmsAuth {
-  /// Construct a new [SmsAuth].
-  SmsAuth(this._api);
-
-  /// The [API] instance containing required configurations to make the requests.
-  final API _api;
+class SmsAuth extends APIDelegate {
+  // ignore: public_member_api_docs
+  SmsAuth(API api) : super(api);
 
   /// Default Recaptcha theme. Could be overridden if user passed a `verifier` to [signInWithPhoneNumber].
   final _recaptchaVerifier =
@@ -78,7 +75,7 @@ class SmsAuth {
   }) async {
     Future<String> _verifyAction;
 
-    if (_api.apiConfig.emulator != null) {
+    if (api.apiConfig.emulator != null) {
       _verifyAction = _verifyEmulator(phoneNumber);
     } else {
       verifier ??= _recaptchaVerifier;
@@ -102,7 +99,7 @@ class SmsAuth {
     String? temporaryProof,
   }) async {
     try {
-      final response = await _api.identityToolkit.verifyPhoneNumber(
+      final response = await api.identityToolkit.verifyPhoneNumber(
         IdentitytoolkitRelyingpartyVerifyPhoneNumberRequest(
           code: smsCode,
           sessionInfo: verificationId,
@@ -126,7 +123,7 @@ class SmsAuth {
   Future<String> _verify(String phoneNumber, RecaptchaVerifier verifier) async {
     final completer = Completer<String>();
 
-    final recaptchaResponse = await _api.identityToolkit.getRecaptchaParam();
+    final recaptchaResponse = await api.identityToolkit.getRecaptchaParam();
 
     final recaptchaArgs = RecaptchaArgs(
       siteKey: recaptchaResponse.recaptchaSiteKey!,
@@ -174,7 +171,7 @@ class SmsAuth {
   }) async {
     try {
       // Send SMS code.
-      final response = await _api.identityToolkit.sendVerificationCode(
+      final response = await api.identityToolkit.sendVerificationCode(
         IdentitytoolkitRelyingpartySendVerificationCodeRequest(
           phoneNumber: phoneNumber,
           recaptchaToken: recaptchaToken,

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/token.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/token.dart
@@ -1,28 +1,5 @@
 part of api;
 
-/// A return type from Idp authentication requests, must be extended by any other response
-/// type for any operation that requires idToken.
-@protected
-class IdTokenResponse {
-  /// Construct a new [IdTokenResponse].
-  IdTokenResponse({required this.idToken, required this.refreshToken});
-
-  /// The idToken returned from a successful authentication operation, valid only for 1 hour.
-  final String idToken;
-
-  /// Th refreshToken returned from a successful authentication operation, used to request new
-  /// [idToken] if it has expired or force refreshed.
-  final String refreshToken;
-
-  /// Json representation of this object.
-  Map<String, dynamic> toJson() {
-    return {
-      'idToken': idToken,
-      'refreshToken': refreshToken,
-    };
-  }
-}
-
 /// Class wrapping methods that calls to the following endpoints:
 /// - `securetoken.googleapis.com`: refresh a Firebase ID token.
 @internal

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/token.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/token.dart
@@ -26,11 +26,9 @@ class IdTokenResponse {
 /// Class wrapping methods that calls to the following endpoints:
 /// - `securetoken.googleapis.com`: refresh a Firebase ID token.
 @internal
-class IdToken {
+class IdToken extends APIDelegate {
   // ignore: public_member_api_docs
-  IdToken(this._api);
-
-  final API _api;
+  IdToken(API api) : super(api);
 
   /// Refresh a user ID token using the refreshToken,
   /// will refresh even if the token hasn't expired.
@@ -46,14 +44,14 @@ class IdToken {
   }
 
   Future<String?> _exchangeRefreshWithIdToken(String? refreshToken) async {
-    final baseUri = _api.apiConfig.emulator != null
-        ? 'http://${_api.apiConfig.emulator!.host}:${_api.apiConfig.emulator!.port}'
+    final baseUri = api.apiConfig.emulator != null
+        ? 'http://${api.apiConfig.emulator!.host}:${api.apiConfig.emulator!.port}'
             '/securetoken.googleapis.com/v1/'
         : 'https://securetoken.googleapis.com/v1/';
 
     final _response = await http.post(
       Uri.parse(
-        '${baseUri}token?key=${_api.apiConfig.apiKey}',
+        '${baseUri}token?key=${api.apiConfig.apiKey}',
       ),
       body: {
         'grant_type': 'refresh_token',

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/token.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/authentication/token.dart
@@ -1,0 +1,69 @@
+part of api;
+
+/// A return type from Idp authentication requests, must be extended by any other response
+/// type for any operation that requires idToken.
+@protected
+class IdTokenResponse {
+  /// Construct a new [IdTokenResponse].
+  IdTokenResponse({required this.idToken, required this.refreshToken});
+
+  /// The idToken returned from a successful authentication operation, valid only for 1 hour.
+  final String idToken;
+
+  /// Th refreshToken returned from a successful authentication operation, used to request new
+  /// [idToken] if it has expired or force refreshed.
+  final String refreshToken;
+
+  /// Json representation of this object.
+  Map<String, dynamic> toJson() {
+    return {
+      'idToken': idToken,
+      'refreshToken': refreshToken,
+    };
+  }
+}
+
+/// Class wrapping methods that calls to the following endpoints:
+/// - `securetoken.googleapis.com`: refresh a Firebase ID token.
+@internal
+class IdToken {
+  // ignore: public_member_api_docs
+  IdToken(this._api);
+
+  final API _api;
+
+  /// Refresh a user ID token using the refreshToken,
+  /// will refresh even if the token hasn't expired.
+  ///
+  Future<String?> refreshIdToken(String? refreshToken) async {
+    try {
+      return await _exchangeRefreshWithIdToken(refreshToken);
+    } on HttpException catch (_) {
+      rethrow;
+    } catch (_) {
+      rethrow;
+    }
+  }
+
+  Future<String?> _exchangeRefreshWithIdToken(String? refreshToken) async {
+    final baseUri = _api.apiConfig.emulator != null
+        ? 'http://${_api.apiConfig.emulator!.host}:${_api.apiConfig.emulator!.port}'
+            '/securetoken.googleapis.com/v1/'
+        : 'https://securetoken.googleapis.com/v1/';
+
+    final _response = await http.post(
+      Uri.parse(
+        '${baseUri}token?key=${_api.apiConfig.apiKey}',
+      ),
+      body: {
+        'grant_type': 'refresh_token',
+        'refresh_token': refreshToken,
+      },
+      headers: {'Content-Typ': 'application/json'},
+    );
+
+    final Map<String, dynamic> _data = json.decode(_response.body);
+
+    return _data['access_token'];
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/emulator.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/emulator.dart
@@ -1,0 +1,59 @@
+part of api;
+
+/// A type to hold the Auth Emulator configurations.
+class EmulatorConfig {
+  EmulatorConfig._({
+    required this.port,
+    required this.host,
+  });
+
+  /// Initialize the Emulator Config using the host and port printed once running `firebase emulators:start`.
+  factory EmulatorConfig.use(String host, int port) {
+    return EmulatorConfig._(port: port, host: host);
+  }
+
+  /// The port on which the emulator suite is running.
+  final String host;
+
+  /// The port on which the emulator suite is running.
+  final int port;
+
+  /// The root URL used to make requests to the locally running emulator.
+  String get rootUrl => 'http://$host:$port/www.googleapis.com/';
+}
+
+/// Call the local auth emulator.
+/// If found, set the instance API to use it for all future requests.
+class AuthEmulator {
+  // ignore: public_member_api_docs
+  AuthEmulator(this._config);
+
+  final APIConfig _config;
+
+  /// TODO: write endpoint details
+  Future<Map> useEmulator(String host, int port) async {
+    // 1. Get the emulator project configs, it must be initialized first.
+    // http://localhost:9099/emulator/v1/projects/{project-id}/config
+    final localEmulator = Uri(
+      scheme: 'http',
+      host: host,
+      port: port,
+      path: '/emulator/v1/projects/${_config.projectId}/config',
+    );
+
+    http.Response response;
+
+    try {
+      response = await http.get(localEmulator);
+    } catch (e) {
+      return {};
+    }
+
+    final Map emulatorProjectConfig = json.decode(response.body);
+
+    // set the the emulator config for this instance.
+    _config.setEmulator(host, port);
+
+    return emulatorProjectConfig;
+  }
+}

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/emulator.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/emulator.dart
@@ -30,7 +30,9 @@ class AuthEmulator {
 
   final APIConfig _config;
 
-  /// TODO: write endpoint details
+  /// Try to connect to the local runnning emulator by getting emulator-specific
+  /// configuration for the specified project. If the connection was successful,
+  /// set local emulator in API configurations to be used for all future requests.
   Future<Map<String, dynamic>> useEmulator(String host, int port) async {
     // 1. Get the emulator project configs, it must be initialized first.
     // http://localhost:9099/emulator/v1/projects/{project-id}/config

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/emulator.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/emulator.dart
@@ -31,7 +31,7 @@ class AuthEmulator {
   final APIConfig _config;
 
   /// TODO: write endpoint details
-  Future<Map> useEmulator(String host, int port) async {
+  Future<Map<String, dynamic>> useEmulator(String host, int port) async {
     // 1. Get the emulator project configs, it must be initialized first.
     // http://localhost:9099/emulator/v1/projects/{project-id}/config
     final localEmulator = Uri(
@@ -49,7 +49,8 @@ class AuthEmulator {
       return {};
     }
 
-    final Map emulatorProjectConfig = json.decode(response.body);
+    final Map<String, dynamic> emulatorProjectConfig =
+        json.decode(response.body);
 
     // set the the emulator config for this instance.
     _config.setEmulator(host, port);

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/api/errors.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/api/errors.dart
@@ -1,0 +1,54 @@
+/// All possible error codes returned from Identity Platform REST API.
+const Map error = {
+  'EMAIL_NOT_FOUND':
+      'There is no user record corresponding to this identifier. The user may have been deleted.',
+  'WRONG_PASSWORD':
+      'The password is invalid or the user does not have a password.',
+  'USER_DISABLED': 'The user account has been disabled by an administrator.',
+  'EMAIL_ALREADY_IN_USE':
+      'The email address is already in use by another account.',
+  'OPERATION_NOT_ALLOWED':
+      'Password sign-in feature is disabled for this project.',
+  'TOO_MANY_ATTEMPTS_TRY_LATER':
+      'This device is blocked due to unusual activity.',
+  'INVALID_EMAIL': 'The email address is badly formatted.',
+  'INVALID_IDENTIFIER':
+      'The identifier provided to `createAuthUri` is invalid.',
+  'NO_CURRENT_USER': 'No user currently signed in.',
+  'INVALID_ID_TOKEN':
+      "The user's credential is no longer valid. The user must sign in or reauthenticate.",
+  'USER_NOT_FOUND':
+      'There is no user record corresponding to this identifier. The user may have been deleted.',
+  'TOKEN_EXPIRED':
+      "The user's credential is no longer valid. The user must sign in again.",
+  'INVALID_REFRESH_TOKEN':
+      "The user's credential is no longer valid. The user must sign in again.",
+  'INVALID_GRANT_TYPE':
+      "The user's credential is no longer valid. The user must sign in again.",
+  'MISSING_REFRESH_TOKEN':
+      "The user's credential is no longer valid. The user must sign in again.",
+  'INVALID_IDP_RESPONSE':
+      "The user's credential is no longer valid. The user must sign in again.",
+  'EXPIRED_OOB_CODE': 'The action code has expired.',
+  'INVALID_OOB_CODE':
+      'The action code is invalid. This can happen if the code is malformed, expired, or has already been used.',
+  'WEAK_PASSWORD': 'Password should be at least 6 characters.',
+  'CREDENTIAL_TOO_OLD_LOGIN_AGAIN':
+      "The user's credential is no longer valid. The user must sign in again.",
+  'FEDERATED_USER_ID_ALREADY_LINKED':
+      'This credential is already associated with a different user account.',
+  'INVALID_PHONE_NUMBER': 'The provided phone number is not valid.',
+  'INVALID_CODE': 'The provided code is not valid.',
+  'UKNOWN': 'Uknown error happened.',
+  'CAPTCHA_CHECK_FAILED':
+      'The reCAPTCHA response token was invalid, expired, or is called from a non-whitelisted domain.',
+  'NEED_CONFIRMATION': 'Account exists with different credential.',
+  'VERIFICATION_CANCELED':
+      'Recaptcha verification process was canceled by user.',
+  'INVALID_VERIFICATION_ID':
+      'The verification ID used to create the phone auth credential is invalid.',
+  'USER_MISMATCH':
+      'The supplied credentials do not correspond to the previously signed in user.',
+  'NO_SUCH_PROVIDER':
+      'User was not linked to an account with the given provider.',
+};

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/confirmation_result.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/confirmation_result.dart
@@ -23,7 +23,7 @@ class ConfirmationResult {
   /// that was sent to the user's mobile device.
   Future<UserCredential> confirm(String verificationCode) async {
     try {
-      final response = await _auth._api.smsAuth.verifyPhoneNumber(
+      final response = await _auth._api.smsAuth.confirmPhoneNumber(
         smsCode: verificationCode,
         verificationId: verificationId,
         idToken: _auth.currentUser?._idToken,
@@ -50,7 +50,7 @@ class ConfirmationResult {
         auth: _auth,
         credential: credential,
         additionalUserInfo: AdditionalUserInfo(
-          isNewUser: response.isNewUser ?? false,
+          isNewUser: response.isNewUser,
           providerId: credential.providerId,
           username: userData.screenName,
           profile: {

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/confirmation_result.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/confirmation_result.dart
@@ -37,7 +37,7 @@ class ConfirmationResult {
           await _auth._api.userAccount.getAccountInfo(response.idToken);
 
       // Map the json response to an actual user.
-      final user = User(userData.toJson()..addAll(response.toJson()), _auth);
+      final user = User(userData..addAll(response.toJson()), _auth);
 
       _auth._updateCurrentUserAndEvents(user, true);
 
@@ -52,10 +52,10 @@ class ConfirmationResult {
         additionalUserInfo: AdditionalUserInfo(
           isNewUser: response.isNewUser,
           providerId: credential.providerId,
-          username: userData.screenName,
+          username: userData['screenName'],
           profile: {
-            'displayName': userData.displayName,
-            'photoUrl': userData.photoUrl
+            'displayName': userData['displayName'],
+            'photoUrl': userData['photoUrl']
           },
         ),
       );

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/confirmation_result.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/confirmation_result.dart
@@ -23,7 +23,7 @@ class ConfirmationResult {
   /// that was sent to the user's mobile device.
   Future<UserCredential> confirm(String verificationCode) async {
     try {
-      final response = await _auth._api.phoneAuthApiDelegate.verifyPhoneNumber(
+      final response = await _auth._api.smsAuth.verifyPhoneNumber(
         smsCode: verificationCode,
         verificationId: verificationId,
         idToken: _auth.currentUser?._idToken,
@@ -33,7 +33,8 @@ class ConfirmationResult {
         throw FirebaseAuthException(code: 'NEED_CONFIRMATION');
       }
 
-      final userData = await _auth._api.getCurrentUser(response.idToken);
+      final userData =
+          await _auth._api.userAccount.getAccountInfo(response.idToken);
 
       // Map the json response to an actual user.
       final user = User(userData.toJson()..addAll(response.toJson()), _auth);

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
@@ -158,10 +158,10 @@ class FirebaseAuth {
     try {
       final response = await _api.emailAndPasswordAuth
           .signInWithEmailAndPassword(email, password);
-      final userData = await _api.userAccount.getAccountInfo(response.idToken);
+      final userData = await _api.userAccount.getAccountInfo(response.idToken!);
 
       // Map the json response to an actual user.
-      final user = User(userData.toJson()..addAll(response.toJson()), this);
+      final user = User(userData..addAll(response.toJson()), this);
 
       _updateCurrentUserAndEvents(user, true);
 
@@ -171,13 +171,14 @@ class FirebaseAuth {
         credential:
             EmailAuthProvider.credential(email: email, password: password),
         additionalUserInfo: AdditionalUserInfo(
-            isNewUser: false,
-            providerId: EmailAuthProvider.PROVIDER_ID,
-            username: userData.screenName,
-            profile: {
-              'displayName': userData.displayName,
-              'photoUrl': userData.photoUrl
-            }),
+          isNewUser: false,
+          providerId: EmailAuthProvider.PROVIDER_ID,
+          username: userData['screenName'],
+          profile: {
+            'displayName': userData['displayName'],
+            'photoUrl': userData['photoUrl']
+          },
+        ),
       );
     } catch (e) {
       throw _getException(e);
@@ -202,10 +203,10 @@ class FirebaseAuth {
     try {
       final response = await _api.emailAndPasswordAuth
           .createUserWithEmailAndPassword(email, password);
-      final userData = await _api.userAccount.getAccountInfo(response.idToken);
+      final userData = await _api.userAccount.getAccountInfo(response.idToken!);
 
       // Map the json response to an actual user.
-      final user = User(userData.toJson()..addAll(response.toJson()), this);
+      final user = User(userData..addAll(response.toJson()), this);
 
       _updateCurrentUserAndEvents(user, true);
 
@@ -214,13 +215,14 @@ class FirebaseAuth {
         credential:
             EmailAuthProvider.credential(email: email, password: password),
         additionalUserInfo: AdditionalUserInfo(
-            isNewUser: true,
-            providerId: EmailAuthProvider.PROVIDER_ID,
-            username: userData.screenName,
-            profile: {
-              'displayName': userData.displayName,
-              'photoUrl': userData.photoUrl
-            }),
+          isNewUser: true,
+          providerId: EmailAuthProvider.PROVIDER_ID,
+          username: userData['screenName'],
+          profile: {
+            'displayName': userData['displayName'],
+            'photoUrl': userData['photoUrl']
+          },
+        ),
       );
     } catch (e) {
       throw _getException(e);
@@ -364,8 +366,7 @@ class FirebaseAuth {
       }
 
       final response = await _api.signUp.signInAnonymously();
-      final userData =
-          (await _api.userAccount.getAccountInfo(response.idToken)).toJson();
+      final userData = await _api.userAccount.getAccountInfo(response.idToken!);
 
       // Map the json response to an actual user.
       final user = User(userData..addAll(response.toJson()), this);
@@ -376,7 +377,9 @@ class FirebaseAuth {
           auth: this,
           additionalUserInfo: AdditionalUserInfo(isNewUser: true),
           credential: const AuthCredential(
-              providerId: providerId, signInMethod: providerId));
+            providerId: providerId,
+            signInMethod: providerId,
+          ));
     } catch (e) {
       throw _getException(e);
     }
@@ -493,7 +496,7 @@ class FirebaseAuth {
           await _api.userAccount.getAccountInfo(response['idToken']);
 
       // Map the json response to an actual user.
-      final user = User(userData.toJson()..addAll(response), this);
+      final user = User(userData..addAll(response), this);
 
       _updateCurrentUserAndEvents(user, true);
 
@@ -503,10 +506,10 @@ class FirebaseAuth {
         additionalUserInfo: AdditionalUserInfo(
           isNewUser: response['isNewUser'] ?? false,
           providerId: credential.providerId,
-          username: userData.screenName,
+          username: userData['screenName'],
           profile: {
-            'displayName': userData.displayName,
-            'photoUrl': userData.photoUrl
+            'displayName': userData['displayName'],
+            'photoUrl': userData['photoUrl']
           },
         ),
       );
@@ -558,7 +561,7 @@ class FirebaseAuth {
     final userData = await _api.userAccount.getAccountInfo(idToken);
 
     // Map the json response to an actual user.
-    return User(userData.toJson()..addAll(signInResponse.toJson()), this);
+    return User(userData..addAll(signInResponse.toJson()), this);
   }
 
   /// TODO
@@ -609,7 +612,7 @@ class FirebaseAuth {
   Future<Map<String, dynamic>> _reloadCurrentUser(String idToken) async {
     try {
       final response = await _api.userAccount.getAccountInfo(idToken);
-      return response.toJson();
+      return response;
     } catch (e) {
       throw _getException(e);
     }

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth.dart
@@ -324,19 +324,6 @@ class FirebaseAuth {
     }
   }
 
-  /// Send a sign in link to email.
-  ///
-  /// Throws [FirebaseAuthException] with following possible codes:
-  /// - `email-not-found`
-  ///   - user doesn't exist
-  Future sendSignInLinkToEmail(String email, [String? continueUrl]) async {
-    try {
-      await _api.emailAndPasswordAuth.sendSignInLinkToEmail(email, continueUrl);
-    } catch (e) {
-      throw _getException(e);
-    }
-  }
-
   /// Asynchronously creates and becomes an anonymous user.
   ///
   /// If there is already an anonymous user signed in, that user will be
@@ -562,28 +549,6 @@ class FirebaseAuth {
 
     // Map the json response to an actual user.
     return User(userData..addAll(signInResponse.toJson()), this);
-  }
-
-  /// TODO
-  Future<UserCredential> signInWithEmailLink(
-      String email, String emailLink) async {
-    throw UnimplementedError('signInWithEmailLink() is not yet implemented.');
-
-    // final response = await _api.signInWithEmailLink(
-    //     email, Uri.parse(emailLink).queryParameters['oobCode']!);
-
-    // final userData = await _api.getCurrentUser(response.idToken!);
-
-    // // Map the json response to an actual user.
-    // final user = User(userData.toJson()..addAll(response.toJson()), this);
-
-    // updateCurrentUserAndEvents(user);
-
-    // return UserCredential._(
-    //   auth: this,
-    //   credential: EmailAuthProvider.credentialWithLink(
-    //       email: email, emailLink: emailLink),
-    // );
   }
 
   /// Starts a phone number verification process for the given phone number.

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth_exception.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/firebase_auth_exception.dart
@@ -4,60 +4,7 @@
 
 import 'package:firebase_core_dart/firebase_core_dart.dart';
 
-/// All possible error codes returned from Identity Platform REST API.
-const Map error = {
-  'EMAIL_NOT_FOUND':
-      'There is no user record corresponding to this identifier. The user may have been deleted.',
-  'WRONG_PASSWORD':
-      'The password is invalid or the user does not have a password.',
-  'USER_DISABLED': 'The user account has been disabled by an administrator.',
-  'EMAIL_ALREADY_IN_USE':
-      'The email address is already in use by another account.',
-  'OPERATION_NOT_ALLOWED':
-      'Password sign-in feature is disabled for this project.',
-  'TOO_MANY_ATTEMPTS_TRY_LATER':
-      'This device is blocked due to unusual activity.',
-  'INVALID_EMAIL': 'The email address is badly formatted.',
-  'INVALID_IDENTIFIER':
-      'The identifier provided to `createAuthUri` is invalid.',
-  'NO_CURRENT_USER': 'No user currently signed in.',
-  'INVALID_ID_TOKEN':
-      "The user's credential is no longer valid. The user must sign in or reauthenticate.",
-  'USER_NOT_FOUND':
-      'There is no user record corresponding to this identifier. The user may have been deleted.',
-  'TOKEN_EXPIRED':
-      "The user's credential is no longer valid. The user must sign in again.",
-  'INVALID_REFRESH_TOKEN':
-      "The user's credential is no longer valid. The user must sign in again.",
-  'INVALID_GRANT_TYPE':
-      "The user's credential is no longer valid. The user must sign in again.",
-  'MISSING_REFRESH_TOKEN':
-      "The user's credential is no longer valid. The user must sign in again.",
-  'INVALID_IDP_RESPONSE':
-      "The user's credential is no longer valid. The user must sign in again.",
-  'EXPIRED_OOB_CODE': 'The action code has expired.',
-  'INVALID_OOB_CODE':
-      'The action code is invalid. This can happen if the code is malformed, expired, or has already been used.',
-  'WEAK_PASSWORD': 'Password should be at least 6 characters.',
-  'CREDENTIAL_TOO_OLD_LOGIN_AGAIN':
-      "The user's credential is no longer valid. The user must sign in again.",
-  'FEDERATED_USER_ID_ALREADY_LINKED':
-      'This credential is already associated with a different user account.',
-  'INVALID_PHONE_NUMBER': 'The provided phone number is not valid.',
-  'INVALID_CODE': 'The provided code is not valid.',
-  'UKNOWN': 'Uknown error happened.',
-  'CAPTCHA_CHECK_FAILED':
-      'The reCAPTCHA response token was invalid, expired, or is called from a non-whitelisted domain.',
-  'NEED_CONFIRMATION': 'Account exists with different credential.',
-  'VERIFICATION_CANCELED':
-      'Recaptcha verification process was canceled by user.',
-  'INVALID_VERIFICATION_ID':
-      'The verification ID used to create the phone auth credential is invalid.',
-  'USER_MISMATCH':
-      'The supplied credentials do not correspond to the previously signed in user.',
-  'NO_SUCH_PROVIDER':
-      'User was not linked to an account with the given provider.',
-};
+import 'api/errors.dart';
 
 /// Wrap the errors from the Identity Platform REST API, usually of type `DetailedApiRequestError`
 /// in a in a Firebase-friendly format to users.

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/user.dart
@@ -310,7 +310,7 @@ class User {
           ),
         );
       } else if (credential is PhoneAuthCredential) {
-        final response = await _auth._api.smsAuth.verifyPhoneNumber(
+        final response = await _auth._api.smsAuth.confirmPhoneNumber(
           phoneNumber: phoneNumber,
           smsCode: credential.smsCode,
           idToken: _idToken,
@@ -324,7 +324,7 @@ class User {
           auth: _auth,
           credential: credential,
           additionalUserInfo: AdditionalUserInfo(
-            isNewUser: response.isNewUser ?? false,
+            isNewUser: response.isNewUser,
             providerId: credential.providerId,
           ),
         );
@@ -341,10 +341,12 @@ class User {
       [RecaptchaVerifier? applicationVerifier]) async {
     try {
       return ConfirmationResult(
-          _auth,
-          (await _auth._api.smsAuth.linkWithPhoneNumber(_idToken, phoneNumber,
-                  verifier: applicationVerifier))
-              .verificationId!);
+        _auth,
+        await _auth._api.smsAuth.signInWithPhoneNumber(
+          phoneNumber,
+          verifier: applicationVerifier,
+        ),
+      );
     } catch (e) {
       throw _auth._getException(e);
     }
@@ -446,7 +448,7 @@ class User {
     _assertSignedOut(_auth);
 
     try {
-      await _auth._api.smsAuth.verifyPhoneNumber(
+      await _auth._api.smsAuth.confirmPhoneNumber(
         idToken: _idToken,
         smsCode: phoneCredential.smsCode,
         verificationId: phoneCredential.verificationId,

--- a/packages/firebase_auth/firebase_auth_dart/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth_dart/lib/src/user.dart
@@ -127,7 +127,7 @@ class User {
         throw FirebaseAuthException(code: 'NO_SUCH_PROVIDER');
       }
 
-      await _auth._api.unlink(_idToken, providerId);
+      await _auth._api.userAccount.deleteLinkedAccount(_idToken, providerId);
       await reload();
 
       return this;
@@ -148,7 +148,7 @@ class User {
     try {
       _assertSignedOut(_auth);
 
-      await _auth._api.delete(_idToken, uid);
+      await _auth._api.userAccount.delete(_idToken, uid);
       await _auth.signOut();
     } catch (e) {
       throw _auth._getException(e);
@@ -186,7 +186,7 @@ class User {
 
   Future<void> _refreshIdToken(bool forceRefresh) async {
     if (forceRefresh || !_decodedIdToken.isValidTimestamp) {
-      _setIdToken(await _auth._api.refreshIdToken(refreshToken));
+      _setIdToken(await _auth._api.idToken.refreshIdToken(refreshToken));
       _auth._updateCurrentUserAndEvents(this);
     }
   }
@@ -196,7 +196,7 @@ class User {
   Future<UserCredential> linkWithCredential(AuthCredential credential) async {
     try {
       if (credential is EmailAuthCredential) {
-        final response = await _auth._api.linkWithEmail(
+        final response = await _auth._api.emailAndPasswordAuth.linkWithEmail(
           _idToken,
           credential: credential,
         );
@@ -215,7 +215,7 @@ class User {
         );
         return await confirmationResult.confirm(credential.smsCode!);
       } else if (credential is GoogleAuthCredential) {
-        final response = await _auth._api.signInWithOAuthCredential(
+        final response = await _auth._api.idpAuth.signInWithOAuthCredential(
           idToken: _idToken,
           providerId: credential.providerId,
           providerIdToken: credential.idToken,
@@ -264,7 +264,7 @@ class User {
           throw FirebaseAuthException(code: 'USER_MISMATCH');
         }
 
-        final response = await _auth._api
+        final response = await _auth._api.emailAndPasswordAuth
             .signInWithEmailAndPassword(credential.email, credential.password!);
 
         _setIdToken(response.idToken);
@@ -286,7 +286,7 @@ class User {
         assert(_auth.app.options.authDomain != null,
             'You should provide authDomain when trying to add Google as auth provider.');
 
-        final response = await _auth._api.signInWithOAuthCredential(
+        final response = await _auth._api.idpAuth.signInWithOAuthCredential(
           providerId: credential.providerId,
           providerIdToken: credential.idToken,
           providerAccessToken: credential.accessToken,
@@ -310,8 +310,7 @@ class User {
           ),
         );
       } else if (credential is PhoneAuthCredential) {
-        final response =
-            await _auth._api.phoneAuthApiDelegate.verifyPhoneNumber(
+        final response = await _auth._api.smsAuth.verifyPhoneNumber(
           phoneNumber: phoneNumber,
           smsCode: credential.smsCode,
           idToken: _idToken,
@@ -339,12 +338,11 @@ class User {
 
   /// Link the current user with the given phone number.
   Future<ConfirmationResult> linkWithPhoneNumber(String phoneNumber,
-      [verifier.RecaptchaVerifier? applicationVerifier]) async {
+      [RecaptchaVerifier? applicationVerifier]) async {
     try {
       return ConfirmationResult(
           _auth,
-          (await _auth._api.phoneAuthApiDelegate.linkWithPhoneNumber(
-                  _idToken, phoneNumber,
+          (await _auth._api.smsAuth.linkWithPhoneNumber(_idToken, phoneNumber,
                   verifier: applicationVerifier))
               .verificationId!);
     } catch (e) {
@@ -385,7 +383,8 @@ class User {
     _assertSignedOut(_auth);
 
     try {
-      await _auth._api.updateEmail(newEmail, _idToken, uid);
+      await _auth._api.emailAndPasswordAccount
+          .updateEmail(newEmail, _idToken, uid);
       await reload();
     } catch (e) {
       throw _auth._getException(e);
@@ -403,7 +402,7 @@ class User {
     _assertSignedOut(_auth);
 
     try {
-      await _auth._api.sendEmailVerification(_idToken);
+      await _auth._api.emailAndPasswordAuth.sendVerificationEmail(_idToken);
     } catch (e) {
       throw _auth._getException(e);
     }
@@ -423,7 +422,10 @@ class User {
     try {
       _assertSignedOut(_auth);
 
-      await _auth._api.updatePassword(newPassword, _idToken);
+      await _auth._api.emailAndPasswordAccount.updatePassword(
+        _idToken,
+        newPassword: newPassword,
+      );
       await reload();
     } catch (e) {
       throw _auth._getException(e);
@@ -444,7 +446,7 @@ class User {
     _assertSignedOut(_auth);
 
     try {
-      await _auth._api.phoneAuthApiDelegate.verifyPhoneNumber(
+      await _auth._api.smsAuth.verifyPhoneNumber(
         idToken: _idToken,
         smsCode: phoneCredential.smsCode,
         verificationId: phoneCredential.verificationId,
@@ -464,7 +466,7 @@ class User {
     try {
       _assertSignedOut(_auth);
 
-      await _auth._api.updateProfile(
+      await _auth._api.userProfile.updateProfile(
         _idToken,
         uid,
         displayName: displayName,
@@ -483,7 +485,7 @@ class User {
     try {
       _assertSignedOut(_auth);
 
-      await _auth._api.updateProfile(
+      await _auth._api.userProfile.updateProfile(
         _idToken,
         uid,
         photoUrl: photoUrl,
@@ -505,7 +507,7 @@ class User {
     try {
       _assertSignedOut(_auth);
 
-      await _auth._api.updateProfile(
+      await _auth._api.userProfile.updateProfile(
         _idToken,
         uid,
         displayName: displayName,

--- a/packages/firebase_auth/firebase_auth_desktop/example/lib/main.dart
+++ b/packages/firebase_auth/firebase_auth_desktop/example/lib/main.dart
@@ -9,24 +9,39 @@ import 'package:yaru/yaru.dart';
 import 'auth.dart';
 import 'profile.dart';
 
-FirebaseOptions get firebaseOptions => const FirebaseOptions(
-      apiKey: 'AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0',
-      authDomain: 'react-native-firebase-testing.firebaseapp.com',
-      databaseURL: 'https://react-native-firebase-testing.firebaseio.com',
-      projectId: 'react-native-firebase-testing',
-      storageBucket: 'react-native-firebase-testing.appspot.com',
-      messagingSenderId: '448618578101',
-      appId: '1:448618578101:web:0b650370bb29e29cac3efc',
-      measurementId: 'G-F79DJ0VFGS',
-    );
+const firebaseOptionsDefault = FirebaseOptions(
+  apiKey: 'AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0',
+  authDomain: 'react-native-firebase-testing.firebaseapp.com',
+  databaseURL: 'https://react-native-firebase-testing.firebaseio.com',
+  projectId: 'react-native-firebase-testing',
+  messagingSenderId: '448618578101',
+  appId: '1:448618578101:web:0b650370bb29e29cac3efc',
+  measurementId: 'G-F79DJ0VFGS',
+);
+
+const firebaseOptionsSecondary = FirebaseOptions(
+  apiKey: 'AIzaSyBzTujHR_zs6CnxcBR-e2PuFcj8U0EfyK0',
+  appId: '1:252234506814:web:a5950ff065e27301a8676f',
+  messagingSenderId: '252234506814',
+  projectId: 'get-started-with-flutter-3bdfb',
+  authDomain: 'get-started-with-flutter-3bdfb.firebaseapp.com',
+  storageBucket: 'get-started-with-flutter-3bdfb.appspot.com',
+);
 
 // Requires that the Firebase Auth emulator is running locally
 // e.g via `melos run firebase:emulator`.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await Firebase.initializeApp(options: firebaseOptions);
-  //await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+  await Firebase.initializeApp(
+    options: firebaseOptionsDefault,
+  );
+  await Firebase.initializeApp(
+    name: 'Secondary',
+    options: firebaseOptionsSecondary,
+  );
+
+  await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
 
   await GoogleSignInDart.register(
     clientId:

--- a/packages/firebase_auth/firebase_auth_desktop/example/lib/profile.dart
+++ b/packages/firebase_auth/firebase_auth_desktop/example/lib/profile.dart
@@ -242,8 +242,7 @@ class _ProfilePageState extends State<ProfilePage> {
           await ExampleDialog.of(context).show('Phone number:', 'Link');
 
       if (phoneNumber != null) {
-        final confirmationResult =
-            await user.linkWithPhoneNumber('+16505550101');
+        final confirmationResult = await user.linkWithPhoneNumber(phoneNumber);
 
         final smsCode =
             // ignore: use_build_context_synchronously

--- a/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
+++ b/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
@@ -220,11 +220,8 @@ class FirebaseAuthDesktop extends FirebaseAuthPlatform {
   @override
   Future<void> sendSignInLinkToEmail(
       String email, ActionCodeSettings actionCodeSettings) async {
-    try {
-      await _delegate!.sendSignInLinkToEmail(email);
-    } catch (e) {
-      throw getFirebaseAuthException(e);
-    }
+    // TODO: implement sendSignInLinkToEmail
+    throw UnimplementedError();
   }
 
   @override
@@ -284,14 +281,8 @@ class FirebaseAuthDesktop extends FirebaseAuthPlatform {
   @override
   Future<UserCredentialPlatform> signInWithEmailLink(
       String email, String emailLink) async {
-    try {
-      return UserCredential(
-        this,
-        await _delegate!.signInWithEmailLink(email, emailLink),
-      );
-    } catch (e) {
-      throw getFirebaseAuthException(e);
-    }
+    // TODO: implement signInWithEmailLink
+    throw UnimplementedError();
   }
 
   @override


### PR DESCRIPTION
# Overview

## Problem statement
Each auth provider and user management method calls a number of API methods in the API layer, which calls Identity Toolkit package. Currently, all the methods are included in one big class.

## Proposed work
Split the API layer as the following ([inspired by JS SDK](https://github.com/firebase/firebase-js-sdk/tree/master/packages/auth/src/api)):

```
|_ api
|____ account_managament
|_______ account.dart
|_______ profile.dart
|_______ email_and_password.dart
|____ authentication
|_______ email_and_password.dart
|_______ recaptcha.dart
|_______ sms.dart
|_______ sign_up.dart
|_______ custom_token.dart
|_______ token.dart
|_______ create_auth_uri.dart
|_______ idp.dart
|____ errors.dart
|____ emulator.dart
|____ api.dart // The main entry point to call this layer, include all required utilities to perform requests
```