### PR TITLE
feat(firebase_auth_desktop): implement signInWithCustomToken

### DIFF
--- a/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
+++ b/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
@@ -276,9 +276,15 @@ class FirebaseAuthDesktop extends FirebaseAuthPlatform {
   }
 
   @override
-  Future<UserCredentialPlatform> signInWithCustomToken(String token) {
-    // TODO: implement signInWithCustomToken
-    throw UnimplementedError();
+  Future<UserCredentialPlatform> signInWithCustomToken(String token) async {
+    try {
+      return UserCredential(
+        this,
+        await _delegate!.signInWithCustomToken(token),
+      );
+    } catch (e) {
+      throw getFirebaseAuthException(e);
+    }
   }
 
   @override


### PR DESCRIPTION
Here's a very simple PR that implements the required call to ```_delegate!.signInWithCustomToken(token)``` to implement the previously unimplemented ```Future<UserCredentialPlatform> signInWithCustomToken(String token)``` method in ```firebase_auth_desktop.dart```.
