### PR TITLE
fix(firebase_auth): add `persistence` parameter for `delegateFor`.

### DIFF
--- a/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
+++ b/packages/firebase_auth/firebase_auth_desktop/lib/firebase_auth_desktop.dart
@@ -99,7 +99,10 @@ class FirebaseAuthDesktop extends FirebaseAuthPlatform {
       _idTokenChangesListeners = <String, StreamController<UserPlatform?>>{};
 
   @override
-  FirebaseAuthPlatform delegateFor({required FirebaseApp app}) {
+  FirebaseAuthPlatform delegateFor(
+      {required FirebaseApp app, Persistence? persistence}) {
+    // The persistence parameter is not used because it's only available on web
+    // based platforms.
     return FirebaseAuthDesktop(app: app);
   }
 

--- a/packages/firebase_auth/firebase_auth_desktop/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth_desktop/test/user_test.dart
@@ -554,7 +554,9 @@ class TestFirebaseAuthPlatform extends FirebaseAuthPlatform {
   TestFirebaseAuthPlatform() : super();
 
   @override
-  FirebaseAuthPlatform delegateFor({FirebaseApp? app}) => this;
+  FirebaseAuthPlatform delegateFor(
+          {FirebaseApp? app, Persistence? persistence}) =>
+      this;
 
   @override
   FirebaseAuthPlatform setInitialValues({


### PR DESCRIPTION
https://github.com/firebase/flutterfire/pull/9138 added the `persistence` parameter for web. The `FirebaseAuthDesktop` extends the `FirebaseAuthPlatform` interface. Therefore, we have to add the parameter to avoid compile errors.